### PR TITLE
ci: desliga deploy MkDocs, deploy Astro automático no ciclo noturno

### DIFF
--- a/.github/workflows/daily-sync.yml
+++ b/.github/workflows/daily-sync.yml
@@ -1,4 +1,7 @@
-name: 🌙 Daily Site Update
+# Sincroniza conteúdo (issues → atividades, gráficos) e commita em docs/.
+# NÃO faz mais deploy: o site agora é o portal Astro, publicado pelo workflow
+# "Deploy portal (Astro)", que dispara via workflow_run quando este termina.
+name: 🌙 Daily Content Sync
 
 on:
   schedule:
@@ -14,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write  # Para commit + push + gh-deploy
+  contents: write  # Para commit + push das atualizações em docs/
   issues: read     # Para ler issues no sync_activities
 
 jobs:
@@ -56,6 +59,5 @@ jobs:
             docs/index.md
           git diff --cached --quiet || git commit -m "chore(bot): atualização noturna de atividades e dashboards [skip ci]"
           git push
-
-      - name: 🚀 Build e deploy do site (MkDocs → gh-pages)
-        run: mkdocs gh-deploy --force --clean
+        # O deploy do portal Astro é disparado automaticamente ao fim deste
+        # workflow (ver workflow_run em deploy-web.yml).

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,7 +1,11 @@
 name: Deploy portal (Astro)
 
-# Deploy automático: publica a cada push no master que toque no portal ou no
-# conteúdo (inclui a atualização noturna do bot em docs/). Também roda sob demanda.
+# Deploy automático do portal Astro (web/) para GitHub Pages.
+# Dispara em:
+#  - push no master tocando web/** ou docs/** (edições humanas)
+#  - conclusão dos workflows-bot que commitam em docs/ com [skip ci]
+#    (o [skip ci] impede o gatilho de push — por isso o workflow_run)
+#  - manualmente (workflow_dispatch)
 on:
   push:
     branches: [master]
@@ -9,6 +13,12 @@ on:
       - 'web/**'
       - 'docs/**'
       - '.github/workflows/deploy-web.yml'
+  workflow_run:
+    workflows:
+      - '🌙 Daily Content Sync'
+      - 'Relatório de Governança'
+      - 'Weekly Repository Catalog'
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -23,8 +33,18 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # em workflow_run, só segue se o workflow-bot terminou com sucesso
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: master        # sempre a HEAD do master (inclui o commit recém-empurrado pelo bot)
+          fetch-depth: 0
+      - name: Carimbo GitOps (commit real do master)
+        id: git
+        run: |
+          echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "msg=$(git log -1 --pretty=%s)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -33,12 +53,12 @@ jobs:
       - name: Install
         working-directory: web
         run: npm ci
-      - name: Build (com carimbo GitOps + todos os painéis)
+      - name: Build (todos os painéis + carimbo)
         working-directory: web
         env:
           PAINEIS: all
-          PUBLIC_GIT_SHA: ${{ github.sha }}
-          PUBLIC_GIT_MSG: ${{ github.event.head_commit.message }}
+          PUBLIC_GIT_SHA: ${{ steps.git.outputs.sha }}
+          PUBLIC_GIT_MSG: ${{ steps.git.outputs.msg }}
           PUBLIC_GIT_WHEN: publicado via GitHub Actions
         run: npm run build
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Fecha o cutover: MkDocs para de fazer deploy; o portal Astro republica sozinho, inclusive no ciclo noturno do bot.

## Mudanças
- **`daily-sync.yml`** — removido o passo `mkdocs gh-deploy --force --clean`. Mantidos o sync de atividades (issues → `docs/atividades/`), a geração de gráficos e o commit em `docs/`. Renomeado para **"🌙 Daily Content Sync"**.
- **`deploy-web.yml`** — além de `push` (web/**, docs/**) e `workflow_dispatch`, passa a disparar via **`workflow_run`** ao fim dos workflows-bot (`Daily Content Sync`, `Relatório de Governança`, `Weekly Repository Catalog`). Necessário porque os commits do bot usam `[skip ci]`, que suprime o gatilho de `push`. Faz checkout de `master` HEAD (pega o commit recém-empurrado) e carimba a `GitStrip` com o commit real.

## Efeito
- Site continua sendo o Astro em `ifesserra-lab.github.io/diretoria`.
- Atualização noturna de conteúdo → redeploy automático do Astro.
- Nenhum deploy concorrente do MkDocs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)