### PR TITLE
feat(web): hero 2 colunas, resumo por relatório, busca corrigida

### DIFF
--- a/web/src/components/Footer.astro
+++ b/web/src/components/Footer.astro
@@ -8,7 +8,7 @@ const repo = 'https://github.com/ifesserra-lab/diretoria';
       <div class="fn">DPPGE · IFES Campus Serra</div>
       <p class="fm">
         Diretoria de Pesquisa, Pós-Graduação e Extensão · Serra/ES<br />
-        Fonte única de verdade — versionada no Git, pública e auditável.
+        Fonte única de verdade — pública e auditável.
       </p>
       <p class="fm">
         <a href={repo}>Editar no GitHub</a> ·

--- a/web/src/components/ReportCard.astro
+++ b/web/src/components/ReportCard.astro
@@ -17,6 +17,7 @@ const badge = { ok: '', wip: '🚧 em construção', exp: 'experimental' }[r.sta
     {badge && <span class={`pill ${r.status}`}>{badge}</span>}
   </div>
   <div class="tt">{r.titulo}</div>
+  <p class="rs">{r.resumo}</p>
   <p class="dd">{r.descricao}</p>
   <Spark kind={r.spark} color={sparkColor} />
   <span class="go">
@@ -34,7 +35,8 @@ const badge = { ok: '', wip: '🚧 em construção', exp: 'experimental' }[r.sta
   .tag{font-family:var(--mono); font-size:10.5px; letter-spacing:.06em; text-transform:uppercase; color:var(--gold); font-weight:600}
   .tag.exp{color:var(--danger)}
   .tt{font-family:var(--serif); font-size:18px; font-weight:600; line-height:1.18}
-  .dd{font-size:13px; color:var(--muted); line-height:1.5; margin:0}
+  .rs{font-size:14px; color:var(--ink); line-height:1.45; margin:0; font-weight:500}
+  .dd{font-size:12.5px; color:var(--muted); line-height:1.5; margin:0; padding-top:8px; border-top:1px solid var(--line)}
   .go{font-family:var(--mono); font-size:12px; color:var(--green); font-weight:600; display:inline-flex; gap:6px; align-items:center; margin-top:2px}
   .rcard:hover .go{gap:9px}
 </style>

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -6,7 +6,7 @@ interface Props { title?: string; description?: string; }
 const { title, description } = Astro.props;
 const siteName = 'Portal DPPGE · IFES Campus Serra';
 const fullTitle = title ? `${title} — ${siteName}` : siteName;
-const desc = description ?? 'Portal de Governança da Diretoria de Pesquisa, Pós-Graduação e Extensão do IFES Campus Serra. Atas, decisões e indicadores versionados no Git — fonte única de verdade, pública e auditável.';
+const desc = description ?? 'Portal de Governança da Diretoria de Pesquisa, Pós-Graduação e Extensão do IFES Campus Serra. Atas, decisões e indicadores — fonte única de verdade, pública e auditável.';
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 <!doctype html>
@@ -45,7 +45,6 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
         <button id="search-close" type="button" aria-label="Fechar">Esc</button>
       </div>
       <div id="search-ui"></div>
-      <p class="sd-hint mono">A busca é indexada no build (Pagefind) — disponível no site publicado.</p>
     </dialog>
 
     <style>
@@ -60,7 +59,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
       #search-close{font-family:var(--mono); font-size:11px; border:1px solid var(--line-strong); background:var(--paper);
         color:var(--muted); border-radius:6px; padding:3px 8px; cursor:pointer}
       #search-ui{padding:16px 18px; min-height:60px}
-      .sd-hint{padding:0 18px 16px; font-size:11.5px; color:var(--faint)}
+      .sd-err{color:var(--muted); font-size:14px; margin:0}
       /* tema Pagefind alinhado ao Registro Vivo */
       #search-ui{--pagefind-ui-primary:var(--green); --pagefind-ui-text:var(--ink);
         --pagefind-ui-background:var(--surface); --pagefind-ui-border:var(--line);
@@ -71,26 +70,45 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
       const dialog = document.getElementById('search-dialog') as HTMLDialogElement | null;
       const openBtn = document.getElementById('search-open');
       const closeBtn = document.getElementById('search-close');
+      const BASE = import.meta.env.BASE_URL; // '/diretoria/'
       let loaded = false;
-      const base = document.documentElement.dataset.base || '';
+
+      function loadScript(src: string) {
+        return new Promise<void>((resolve, reject) => {
+          const s = document.createElement('script');
+          s.src = src; s.async = true;
+          s.onload = () => resolve();
+          s.onerror = () => reject(new Error('falha ao carregar ' + src));
+          document.head.appendChild(s);
+        });
+      }
 
       async function ensurePagefind() {
         if (loaded || !dialog) return;
         loaded = true;
         const css = document.createElement('link');
         css.rel = 'stylesheet';
-        css.href = `${import.meta.env.BASE_URL}pagefind/pagefind-ui.css`;
+        css.href = `${BASE}pagefind/pagefind-ui.css`;
         document.head.appendChild(css);
         try {
-          // @ts-ignore — gerado no build pelo Pagefind
-          await import(/* @vite-ignore */ `${import.meta.env.BASE_URL}pagefind/pagefind-ui.js`);
-          // @ts-ignore
-          new PagefindUI({ element: '#search-ui', showSubResults: true, translations: {
-            placeholder: 'Buscar atas, decisões, comissões…', zero_results: 'Nada encontrado para [SEARCH_TERM].'
-          }});
+          // pagefind-ui.js NÃO é ESM — carrega via <script> e usa o global PagefindUI
+          await loadScript(`${BASE}pagefind/pagefind-ui.js`);
+          const PagefindUI = (window as any).PagefindUI;
+          if (typeof PagefindUI !== 'function') throw new Error('PagefindUI indisponível');
+          new PagefindUI({
+            element: '#search-ui',
+            bundlePath: `${BASE}pagefind/`,   // índice fica sob /diretoria/pagefind/
+            showSubResults: true,
+            showImages: false,
+            translations: {
+              placeholder: 'Buscar atas, decisões, comissões…',
+              zero_results: 'Nada encontrado para [SEARCH_TERM].',
+            },
+          });
         } catch (e) {
+          loaded = false; // permite nova tentativa
           const el = document.getElementById('search-ui');
-          if (el) el.innerHTML = '<p style="color:var(--muted);font-size:14px;margin:0">A busca fica ativa no site publicado (índice gerado no build).</p>';
+          if (el) el.innerHTML = '<p class="sd-err">Não foi possível carregar a busca. Recarregue a página e tente novamente.</p>';
         }
       }
       function open() { ensurePagefind(); dialog?.showModal(); }

--- a/web/src/lib/reports.ts
+++ b/web/src/lib/reports.ts
@@ -7,7 +7,8 @@ export type Report = {
   slug: string;
   titulo: string;
   tag: string;
-  descricao: string;
+  resumo: string;      // explicação curta, linguagem simples — o que o painel responde
+  descricao: string;   // detalhe técnico (fontes, métricas, ressalvas)
   status: 'ok' | 'wip' | 'exp';
   path?: string;
   ext?: string;
@@ -19,61 +20,73 @@ export type Report = {
 export const reports: Report[] = [
   {
     slug: 'campus-serra', titulo: 'Extensão — Campus Serra (SRC)', tag: 'Extensão · SRC',
+    resumo: 'Tudo o que o campus faz de extensão, num painel navegável por ação, atividade e pessoa.',
     descricao: '201 ações, 525 atividades e 757 extensionistas. Busca, jornada do formado, pendências e dados abertos (JSON + llms.txt).',
     status: 'ok', path: 'relatorios/campus-serra/index.html', ext: 'https://ifesserra-lab.github.io/src/', heavy: true, destaque: true, spark: 'area',
   },
   {
     slug: 'roi-impacto-pesquisa', titulo: 'ROI e Impacto da Pesquisa', tag: 'Multidimensional',
+    resumo: 'Vale a pena investir em pesquisa? Quatro métodos internacionais tentam medir o retorno.',
     descricao: 'Payback · CAHS · Manifesto de Leiden/DORA · REF. Painel de 7 dimensões, valores em ordem de grandeza. Exercício metodológico.',
     status: 'ok', path: 'relatorios/roi-impacto-pesquisa.html', destaque: true, spark: 'bars',
   },
   {
     slug: 'egressos', titulo: 'Egressos — Impacto na Carreira', tag: 'Experimental',
+    resumo: 'O que aconteceu com quem passou pela base de pesquisa e extensão do campus.',
     descricao: 'Trajetória de 28 egressos da mesma base (IC, LEDS/IFES, Morpheus) até posições sênior. Anonimizado A–AB, dados preliminares.',
     status: 'exp', path: 'relatorios/egressos/index.html', ext: 'https://ifesserra-lab.github.io/egressos/', heavy: true, destaque: true, spark: 'line',
   },
   {
     slug: 'pesquisa-x-extensao', titulo: 'Pesquisa × Extensão', tag: 'Cruzamento',
+    resumo: 'Quem faz pesquisa também faz extensão? E isso atrapalha a produção científica?',
     descricao: '78% dos coordenadores de pesquisa também fazem extensão — e fazer extensão não reduz o impacto científico (FWCI mediano).',
     status: 'ok', path: 'relatorios/pesquisa-x-extensao.html', spark: 'line',
   },
   {
     slug: 'captacao-projetos', titulo: 'Captação de Projetos — FAPES + FACTO', tag: 'Fomento',
+    resumo: 'Quanto e como o campus captou em projetos de pesquisa ao longo dos anos.',
     descricao: 'Projetos por ano, captação em índice, bolsistas ao longo do tempo, rubricas do orçamento e liderança de captação por coordenador.',
     status: 'ok', path: 'relatorios/captacao-projetos.html', spark: 'area',
   },
   {
     slug: 'indice-extensao', titulo: 'Índice de Extensão (FORPROEX)', tag: '5 dimensões',
+    resumo: 'A extensão do campus lida frente às cinco dimensões oficiais de avaliação (FORPROEX).',
     descricao: 'A extensão do campus nas cinco dimensões dos Indicadores Brasileiros de Extensão (FORPROEX, 2017), só com dados verificáveis.',
     status: 'ok', path: 'relatorios/indice-extensao.html', spark: 'bars',
   },
   {
     slug: 'docentes-veiculos-impacto', titulo: 'Docentes — Veículos e Impacto', tag: 'Bibliometria',
+    resumo: 'Onde os docentes publicam e qual o impacto real desses trabalhos.',
     descricao: 'Onde os docentes publicam (SJR/SCImago Q1–Q4, Qualis CAPES) cruzado com impacto real (citações, FWCI, h/g/m) via OpenAlex.',
     status: 'ok', path: 'relatorios/docentes-veiculos-impacto.html', spark: 'bars',
   },
   {
     slug: 'dashboard-impacto-docentes', titulo: 'Dashboard de Impacto dos Docentes', tag: 'Uso interno',
+    resumo: 'Os indicadores de impacto científico dos docentes reunidos num painel só.',
     descricao: 'Ascensão, produção de elite (top 10%/1%), eficiência fracionada, concentração (Lorenz/Gini), benchmark por área. Simulação.',
     status: 'wip', path: 'relatorios/dashboard-impacto-docentes.html', spark: 'line',
   },
   {
     slug: 'ppp-edital-13-2026', titulo: 'Edital PRPPG 13/2026 — PPP', tag: 'Elegibilidade',
+    resumo: 'Quais docentes se enquadram no edital de produtividade em pesquisa (PQ-1/2/3).',
     descricao: 'Elegibilidade dos docentes ao Programa Pesquisador de Produtividade (PQ-1/2/3): pontuação por percentil e orientações concluídas.',
     status: 'ok', path: 'relatorios/ppp-edital-13-2026.html', spark: 'bars',
   },
   {
     slug: 'pesquisa-na-formacao', titulo: 'Pesquisa na Formação', tag: 'Formação',
+    resumo: 'Quanto os formandos da graduação e do mestrado se envolvem com pesquisa.',
     descricao: 'Participação em pesquisa dos egressos da graduação (SI e ECA) e a trajetória dos discentes do mestrado PPComp.',
     status: 'ok', path: 'relatorios/pesquisa-na-formacao.html', spark: 'area',
   },
   {
     slug: 'formandos-pesquisa-detalhado', titulo: 'Formandos × Pesquisa (detalhado)', tag: 'Dados nominais',
+    resumo: 'A versão operacional e nominal do relatório de formandos — para a gestão.',
     descricao: 'Versão operacional: cotas, fomento por agência, tempo ajustado por curso, funil IC→TCC e pipeline graduação→mestrado.',
     status: 'wip', path: 'relatorios/formandos-pesquisa-detalhado.html', spark: 'line',
   },
   {
     slug: 'rede-colaboracao', titulo: 'Rede de Colaboração', tag: 'Interativo',
+    resumo: 'Quem publica com quem — o mapa de coautoria dos pesquisadores do campus.',
     descricao: 'Ego-rede de coautoria por pesquisador, detecção de comunidades (Louvain) e padrões por área. Versão preliminar.',
     status: 'wip', path: 'relatorios/rede-colaboracao.html', spark: 'line',
   },

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -1,13 +1,29 @@
 ---
 import Base from '../layouts/Base.astro';
-import GitStrip from '../components/GitStrip.astro';
 import QuickCard from '../components/QuickCard.astro';
 import StatStrip from '../components/StatStrip.astro';
 import ReportCard from '../components/ReportCard.astro';
 import Icon from '../components/Icon.astro';
 import { reports } from '../lib/reports';
+import { getCollection } from 'astro:content';
+import { displayTitle, dateFromId, fmtDate } from '../lib/derive';
+
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const destaques = reports.filter((r) => r.destaque);
+
+// registro recente (dados reais das coleções)
+const notModelo = (e: any) => !/^(modelo|template)/i.test(e.id.split('/').pop() ?? '');
+const atas = (await getCollection('atas')).filter(notModelo)
+  .sort((a, b) => (dateFromId(b.id)?.getTime() ?? 0) - (dateFromId(a.id)?.getTime() ?? 0));
+const decisoes = (await getCollection('decisoes')).filter(notModelo)
+  .sort((a, b) => b.id.localeCompare(a.id));
+const ultimaAta = atas[0];
+const ultimaDec = decisoes[0];
+const git = {
+  sha: (import.meta.env.PUBLIC_GIT_SHA || '').slice(0, 7) || '7b02688',
+  msg: import.meta.env.PUBLIC_GIT_MSG || 'egressos: metodologia + item na nav',
+};
+
 const team = [
   { nome: 'Paulo Sérgio Jr.', papel: 'Diretor', area: 'Geral' },
   { nome: 'Richard Godinez', papel: 'Coordenador', area: 'Pesquisa' },
@@ -24,23 +40,45 @@ const quick = [
 ];
 ---
 <Base>
-  <!-- HERO -->
+  <!-- HERO — duas colunas: tese à esquerda, registro recente à direita -->
   <section class="hero">
     <div class="wrap inner">
-      <p class="eyebrow green">Fonte única de verdade</p>
-      <h1>Toda decisão da diretoria tem uma origem rastreável.</h1>
-      <p class="sub">Atas, diretrizes e indicadores da pesquisa, pós-graduação e extensão do
-        IFES Campus Serra — versionados no Git, públicos e auditáveis.</p>
-      <div class="btns">
-        <a class="btn primary" href={base + '/relatorios'}>Ver relatórios <Icon name="arrow" size={16} /></a>
-        <a class="btn ghost" href={base + '/decisoes'}>Últimas decisões</a>
+      <div class="lead-col">
+        <p class="eyebrow green">Fonte única de verdade</p>
+        <h1>Toda decisão da diretoria tem uma origem rastreável.</h1>
+        <p class="sub">Atas, diretrizes e indicadores da pesquisa, pós-graduação e extensão do
+          IFES Campus Serra — públicos e auditáveis.</p>
+        <div class="btns">
+          <a class="btn primary" href={base + '/relatorios'}>Ver relatórios <Icon name="arrow" size={16} /></a>
+          <a class="btn ghost" href={base + '/decisoes'}>Últimas decisões</a>
+        </div>
       </div>
+
+      <aside class="panel" aria-label="Registro recente">
+        <p class="p-t mono">Registro recente</p>
+        <a class="p-row git" href="https://github.com/ifesserra-lab/diretoria/commits/master">
+          <span class="sha mono">{git.sha}</span>
+          <span class="m">{git.msg}</span>
+          <span class="tagline mono">atualização automática</span>
+        </a>
+        {ultimaAta && (
+          <a class="p-row" href={`${base}/atas/${ultimaAta.id}`}>
+            <span class="k mono">Última ata</span>
+            <span class="v">{displayTitle(ultimaAta as any)}</span>
+            {dateFromId(ultimaAta.id) && <span class="d mono">{fmtDate(dateFromId(ultimaAta.id))}</span>}
+          </a>
+        )}
+        {ultimaDec && (
+          <a class="p-row" href={`${base}/decisoes/${ultimaDec.id}`}>
+            <span class="k mono">Última decisão</span>
+            <span class="v">{displayTitle(ultimaDec as any)}</span>
+          </a>
+        )}
+      </aside>
     </div>
   </section>
 
   <div class="wrap stack">
-    <GitStrip />
-
     <!-- ACESSO RÁPIDO -->
     <div class="qgrid">
       {quick.map((q) => <QuickCard {...q} />)}
@@ -87,11 +125,32 @@ const quick = [
 <style>
   .hero{position:relative; overflow:hidden; border-bottom:1px solid var(--line)}
   .hero:before{content:''; position:absolute; inset:0; pointer-events:none;
-    background:radial-gradient(120% 100% at 88% -20%, var(--green-soft) 0%, transparent 55%)}
-  .hero .inner{position:relative; padding:72px 24px 60px; max-width:760px}
-  .hero h1{font-size:clamp(34px,5.6vw,60px); margin-top:16px; letter-spacing:-.018em}
-  .hero .sub{font-size:19px; color:var(--muted); margin-top:20px; max-width:600px; line-height:1.55}
-  .btns{display:flex; gap:12px; margin-top:30px; flex-wrap:wrap}
+    background:radial-gradient(90% 120% at 100% -10%, var(--green-soft) 0%, transparent 50%)}
+  .hero .inner{position:relative; padding:56px 24px 52px; display:grid;
+    grid-template-columns:minmax(0,1.5fr) minmax(300px,1fr); gap:48px; align-items:center}
+  .lead-col{min-width:0}
+  .hero h1{font-size:clamp(32px,4.6vw,52px); margin-top:14px; letter-spacing:-.018em; max-width:16ch}
+  .hero .sub{font-size:18px; color:var(--muted); margin-top:18px; max-width:52ch; line-height:1.55}
+  .btns{display:flex; gap:12px; margin-top:26px; flex-wrap:wrap}
+
+  /* painel "registro recente" */
+  .panel{background:var(--surface); border:1px solid var(--line); border-radius:14px; padding:8px 6px; box-shadow:var(--shadow)}
+  .p-t{font-size:11px; letter-spacing:.09em; text-transform:uppercase; color:var(--faint); padding:12px 14px 8px}
+  .p-row{display:grid; gap:2px; padding:12px 14px; border-top:1px solid var(--line); text-decoration:none; color:var(--ink)}
+  .p-row:first-of-type{border-top:0}
+  .p-row:hover{background:var(--surface-2); text-decoration:none}
+  .p-row.git{grid-template-columns:auto 1fr; column-gap:9px; align-items:baseline}
+  .p-row.git .sha{color:var(--gold); font-weight:700; font-size:12.5px}
+  .p-row.git .m{color:var(--ink); font-size:13px; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap}
+  .p-row.git .tagline{grid-column:2; color:var(--faint); font-size:10.5px; letter-spacing:.04em}
+  .p-row .k{font-family:var(--mono); font-size:10.5px; letter-spacing:.06em; text-transform:uppercase; color:var(--gold)}
+  .p-row .v{font-family:var(--serif); font-size:15px; font-weight:600; line-height:1.2}
+  .p-row:hover .v{color:var(--green)}
+  .p-row .d{font-size:11.5px; color:var(--faint)}
+  @media (max-width:860px){
+    .hero .inner{grid-template-columns:1fr; gap:32px; padding:48px 24px 44px}
+    .panel{max-width:520px}
+  }
 
   .stack{display:flex; flex-direction:column; gap:44px; padding-top:40px; padding-bottom:20px}
   .qgrid{display:grid; grid-template-columns:repeat(3,1fr); gap:1px; background:var(--line);


### PR DESCRIPTION
Ajustes na home e nos relatórios + correção da busca.

- **Home / espaço**: hero em duas colunas — tese à esquerda, painel **"Registro recente"** à direita (commit + última ata + última decisão, dados reais das coleções). Preenche o vazio à direita e reduz a altura ociosa.
- **"versionado no Git"** removido do hero, do rodapé e da meta description.
- **Relatórios**: cada painel ganha um `resumo` em linguagem simples (o que ele responde), em destaque no card; a descrição técnica vira detalhe secundário.
- **Busca (Pagefind)**: `pagefind-ui.js` não é ESM — passou a ser carregado via `<script>` com `bundlePath` correto (`/diretoria/pagefind/`). Remove o texto-dica permanente. Corrige a busca que não abria no site publicado.

Build: 35 páginas, Pagefind 45 páginas indexadas, assets `pagefind-ui.*` presentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)