### PR TITLE
feat(web): link llms.txt no rodapé

### DIFF
--- a/web/src/components/Footer.astro
+++ b/web/src/components/Footer.astro
@@ -13,7 +13,8 @@ const repo = 'https://github.com/ifesserra-lab/diretoria';
       <p class="fm">
         <a href={repo}>Editar no GitHub</a> ·
         <a href={base + '/relatorios'}>Relatórios</a> ·
-        <a href="https://github.com/orgs/ifesserra-lab/projects/7">Project #7</a>
+        <a href="https://github.com/orgs/ifesserra-lab/projects/7">Project #7</a> ·
+        <a href={base + '/llms.txt'} title="Índice do portal em Markdown para assistentes de IA (spec llmstxt.org)">llms.txt</a>
       </p>
     </div>
     <div class="fm meta">


### PR DESCRIPTION
Adiciona link `llms.txt` no rodapé do portal (ao lado de Relatórios e Project #7), com tooltip explicando que é o índice em Markdown para assistentes de IA (spec llmstxt.org). Antes o arquivo existia mas nada no site apontava para ele.

Testado com `npx astro build` — link presente em todas as páginas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)