### PR TITLE
feat(relatorios): balanço de gestão dos 6 meses em sete movimentos

### DIFF
--- a/docs/relatorios/balanco-2026.html
+++ b/docs/relatorios/balanco-2026.html
@@ -1,0 +1,1035 @@
+<!doctype html>
+<html lang="pt-br">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Transparência: descobrindo o campus e seus impactos — DPPGE · IFES Campus Serra</title>
+<meta name="description" content="Balanço dos primeiros seis meses de gestão da DPPGE do IFES Campus Serra em sete movimentos: extensão, pesquisa, egressos, fomento, infraestrutura de dados, Escritório de Projetos e a visão para 2027. Cada bloco mostra a própria fonte." />
+<meta name="author" content="Diretoria de Pesquisa, Pós-Graduação e Extensão — IFES Campus Serra" />
+<meta property="og:type" content="article" />
+<meta property="og:title" content="Transparência: descobrindo o campus e seus impactos" />
+<meta property="og:description" content="Balanço dos seis meses de gestão da DPPGE, construído sobre os dados abertos do campus." />
+<meta property="og:locale" content="pt_BR" />
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' fill='%23006b3f'/%3E%3Crect x='3' y='3' width='4' height='4' fill='%23fff'/%3E%3C/svg%3E" />
+</head>
+<body>
+<style>
+  :root{
+    /* identidade IFES */
+    --green:#009640; --green-dark:#006b3f; --yellow:#fdb913; --red:#e30613; --blue:#0072bc;
+    /* neutros com viés verde — escolhidos, não herdados */
+    --paper:#f6f8f6; --surface:#ffffff; --ink:#16241d; --ink-2:#54655c; --muted:#8a9990;
+    --line:#e2e8e3; --line-2:#cfd9d2; --field:#eef2ef;
+    --data-mute:#a8b6ac; --accent:var(--green-dark);
+    --sans:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+    --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;
+    --wrap:1120px;
+    --ifes-flag:linear-gradient(90deg,var(--green) 0 25%,var(--yellow) 25% 50%,
+      var(--red) 50% 75%,var(--blue) 75% 100%);
+    --shadow:0 1px 2px rgba(22,36,29,.05),0 12px 28px -18px rgba(22,36,29,.35);
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --paper:#0d1411; --surface:#141d19; --ink:#eaf1ec; --ink-2:#a9b8ae; --muted:#75857c;
+    --line:#1f2c26; --line-2:#2b3a32; --field:#111a16;
+    --data-mute:#4a5b51; --green:#22ab5b; --blue:#3f9bd8; --accent:#37b46e;
+    --shadow:0 1px 2px rgba(0,0,0,.4),0 14px 30px -20px rgba(0,0,0,.8);
+  }}
+  :root[data-theme="dark"]{
+    --paper:#0d1411; --surface:#141d19; --ink:#eaf1ec; --ink-2:#a9b8ae; --muted:#75857c;
+    --line:#1f2c26; --line-2:#2b3a32; --field:#111a16;
+    --data-mute:#4a5b51; --green:#22ab5b; --blue:#3f9bd8; --accent:#37b46e;
+    --shadow:0 1px 2px rgba(0,0,0,.4),0 14px 30px -20px rgba(0,0,0,.8);
+  }
+  :root[data-theme="light"]{
+    --paper:#f6f8f6; --surface:#ffffff; --ink:#16241d; --ink-2:#54655c; --muted:#8a9990;
+    --line:#e2e8e3; --line-2:#cfd9d2; --field:#eef2ef;
+    --data-mute:#a8b6ac; --green:#009640; --blue:#0072bc; --accent:#006b3f;
+    --shadow:0 1px 2px rgba(22,36,29,.05),0 12px 28px -18px rgba(22,36,29,.35);
+  }
+
+  *{box-sizing:border-box;}
+  body{margin:0;background:var(--paper);color:var(--ink);font-family:var(--sans);
+    font-size:16px;line-height:1.6;-webkit-text-size-adjust:100%;overflow-x:hidden;}
+  .wrap{max-width:var(--wrap);margin:0 auto;padding:0 28px;}
+  h1,h2,h3{margin:0;text-wrap:balance;}
+  p{margin:0;}
+  :where(a,button):focus-visible{outline:2px solid var(--accent);outline-offset:3px;}
+  @media (prefers-reduced-motion:reduce){*{transition:none !important;animation:none !important;}}
+
+  .eyebrow{font-family:var(--mono);font-size:11.5px;letter-spacing:.11em;text-transform:uppercase;
+    color:var(--accent);font-weight:600;}
+  .tnum{font-variant-numeric:tabular-nums;}
+
+  /* Faixa institucional IFES como barra de progresso: começa fantasma e vai
+     ganhando cor conforme a apresentação avança. Bandeira completa = fim. */
+  .progress{position:fixed;top:0;left:0;right:0;height:4px;z-index:90;background:var(--paper);}
+  .progress::before{content:"";position:absolute;inset:0;background:var(--ifes-flag);
+    background-size:100vw 100%;opacity:.15;}
+  .progress i{position:absolute;top:0;bottom:0;left:0;width:0;background:var(--ifes-flag);
+    background-size:100vw 100%;transition:width .15s linear;}
+  @media (prefers-reduced-motion:reduce){.progress i{transition:none;}}
+  @media print{.progress{display:none;}}
+
+  /* ---------------- capa ---------------- */
+  .cover{padding:76px 0 64px;border-bottom:1px solid var(--line);}
+  .cover h1{font-size:clamp(38px,7vw,78px);line-height:1;letter-spacing:-.035em;font-weight:800;
+    margin-top:20px;max-width:15ch;}
+  .cover h1 .b{color:var(--green);display:block;}
+  .cover .lede{margin-top:26px;font-size:clamp(17px,2.2vw,21px);color:var(--ink-2);
+    max-width:58ch;line-height:1.55;}
+  /* flex, não grid: com 7 itens um grid deixaria células vazias mostrando o
+     fundo das linhas — aqui a última fileira só estica. */
+  .toc{display:flex;flex-wrap:wrap;gap:10px;margin-top:48px;}
+  .toc a{flex:1 1 190px;border:1px solid var(--line);background:var(--paper);
+    padding:18px 18px 20px;display:grid;gap:7px;align-content:start;
+    text-decoration:none;color:inherit;transition:background .15s,border-color .15s;}
+  .toc a:hover{background:var(--surface);border-color:var(--line-2);}
+  .toc .k{font-family:var(--mono);font-size:12px;color:var(--muted);}
+  .toc .t{font-size:15px;font-weight:600;line-height:1.3;letter-spacing:-.01em;}
+  .toc a:hover .t{color:var(--accent);}
+  @media(max-width:480px){.toc a{flex-basis:100%;}}
+
+  /* ---------------- atos ---------------- */
+  .act{padding:72px 0;border-bottom:1px solid var(--line);}
+  /* alternância e cores por id — a capa também é <section>, então nth-of-type mentiria */
+  #ato-2,#ato-4{background:var(--surface);}
+  .act .head{display:grid;grid-template-columns:64px minmax(0,1fr);gap:24px;align-items:start;}
+  .act .num{font-family:var(--mono);font-size:13px;font-weight:600;color:var(--muted);
+    padding-top:11px;border-top:3px solid var(--green);}
+  #ato-2 .num{border-top-color:var(--blue);}
+  #ato-3 .num{border-top-color:var(--red);}
+  #ato-4 .num{border-top-color:var(--yellow);}
+  #gestao .num{border-top-color:var(--line-2);}
+  #ato-6{background:var(--surface);}
+  #ato-6 .num{border-top-color:var(--green-dark);}
+
+  #ato-7 .num{border-top-color:var(--green);}
+
+  /* equipe do escritório */
+  .equipe{display:grid;grid-template-columns:repeat(5,1fr);gap:1px;background:var(--line);
+    border:1px solid var(--line);}
+  .equipe .pe{background:var(--paper);padding:24px 18px;display:grid;justify-items:center;gap:12px;}
+  .equipe .av{width:52px;height:52px;border-radius:50%;display:grid;place-items:center;
+    background:color-mix(in srgb,var(--green) 16%,transparent);color:var(--green-dark);
+    font-size:20px;font-weight:700;}
+  .equipe .nm{font-size:15.5px;font-weight:600;letter-spacing:-.01em;}
+  .equipe-nota{margin-top:18px;font-size:14.5px;color:var(--ink-2);max-width:56ch;line-height:1.55;}
+  @media(max-width:760px){.equipe{grid-template-columns:repeat(3,1fr);}}
+  @media(max-width:420px){.equipe{grid-template-columns:repeat(2,1fr);}}
+
+  /* frentes do escritório */
+  .frentes{display:grid;grid-template-columns:repeat(2,1fr);gap:1px;background:var(--line);
+    border:1px solid var(--line);}
+  .frentes .fr{background:var(--paper);padding:24px;display:grid;gap:9px;align-content:start;}
+  .frentes .n{font-family:var(--mono);font-size:12px;color:var(--green-dark);font-weight:600;}
+  .frentes h3{font-size:17px;font-weight:600;letter-spacing:-.015em;}
+  .frentes p{font-size:14.5px;color:var(--ink-2);line-height:1.55;}
+  .frentes p b{color:var(--ink);font-weight:600;}
+  .frentes .ind{font-family:var(--mono);font-size:11.5px;color:var(--muted);
+    border-top:1px solid var(--line);padding-top:10px;margin-top:3px;}
+  @media(max-width:700px){.frentes{grid-template-columns:1fr;}}
+  .act h2{font-size:clamp(27px,4.2vw,44px);letter-spacing:-.028em;font-weight:700;line-height:1.08;
+    max-width:20ch;}
+  .act .lede{margin-top:18px;font-size:clamp(16.5px,1.9vw,19px);color:var(--ink-2);
+    max-width:62ch;line-height:1.6;}
+  .act .lede b{color:var(--ink);font-weight:600;}
+  @media(max-width:700px){
+    .act{padding:56px 0;}
+    .act .head{grid-template-columns:1fr;gap:14px;}
+    .act .num{border-top:0;padding-top:0;}
+  }
+
+  /* figura */
+  .fig{margin-top:44px;background:var(--paper);border:1px solid var(--line);padding:28px;}
+  #ato-2 .fig,#ato-4 .fig,#ato-6 .fig{background:var(--field);}
+  #ato-6 .equipe .pe,#ato-6 .frentes .fr{background:var(--paper);}
+  .fig + .fig{margin-top:20px;}
+  .fig .cap{font-family:var(--mono);font-size:11.5px;letter-spacing:.06em;text-transform:uppercase;
+    color:var(--muted);margin-bottom:22px;}
+  .figscroll{overflow-x:auto;}
+
+  /* número-herói */
+  .hero-n{display:flex;flex-wrap:wrap;align-items:baseline;gap:14px;margin-bottom:26px;}
+  .hero-n .v{font-family:var(--mono);font-size:clamp(50px,9vw,86px);font-weight:600;
+    letter-spacing:-.04em;line-height:.9;color:var(--green);}
+  .hero-n .d{font-size:16px;color:var(--ink-2);max-width:26ch;line-height:1.4;}
+
+  /* barras horizontais */
+  .bars{display:grid;gap:11px;}
+  .bar{display:grid;grid-template-columns:104px minmax(0,1fr) 84px;gap:14px;align-items:center;}
+  .bar .lbl{font-family:var(--mono);font-size:12.5px;color:var(--ink-2);text-align:right;}
+  .bar .track{display:block;height:22px;background:transparent;position:relative;}
+  /* display:block é obrigatório — <span> inline ignora width/height */
+  .bar .fill{display:block;height:100%;border-radius:0 4px 4px 0;background:var(--data-mute);
+    width:0;transition:width .7s cubic-bezier(.2,.7,.3,1),filter .12s;}
+  .step .blk{transition:height .6s cubic-bezier(.2,.7,.3,1);}
+  .bar[data-hl="1"] .fill{background:var(--green);}
+  .bar[data-hl="1"] .lbl{color:var(--ink);font-weight:600;}
+  .bar:hover .fill{filter:brightness(1.08);}
+  .bar .val{font-family:var(--mono);font-size:13px;color:var(--ink);text-align:right;}
+  .bar[data-hl="0"] .val{color:var(--ink-2);}
+  @media(max-width:560px){.bar{grid-template-columns:78px minmax(0,1fr) 66px;gap:9px;}
+    .bar .lbl{font-size:11px;} .bar .val{font-size:12px;}}
+
+  /* colchete do subtotal */
+  .bracket{display:grid;grid-template-columns:104px minmax(0,1fr) 84px;gap:14px;
+    align-items:center;margin-top:4px;}
+  .bracket .z{grid-column:2;display:flex;align-items:center;gap:11px;}
+  .bracket .rule{height:1px;background:var(--green);flex:none;}
+  .bracket .txt{font-family:var(--mono);font-size:12px;color:var(--green);white-space:nowrap;}
+  @media(max-width:560px){.bracket{grid-template-columns:78px minmax(0,1fr) 66px;gap:9px;}}
+
+  /* ledger da gestão */
+  .bars-plain{display:grid;grid-template-columns:repeat(4,1fr);gap:1px;background:var(--line);
+    border:1px solid var(--line);}
+  .bars-plain .pl{background:var(--paper);padding:20px 18px;display:grid;gap:4px;align-content:start;}
+  .bars-plain b{font-family:var(--mono);font-size:32px;font-weight:600;letter-spacing:-.03em;
+    color:var(--green);line-height:1;}
+  .bars-plain span{font-size:13.5px;font-weight:600;color:var(--ink);margin-top:6px;}
+  .bars-plain em{font-style:normal;font-size:12.5px;color:var(--ink-2);line-height:1.4;}
+  .bars-plain.cinco{grid-template-columns:repeat(5,1fr);}
+  @media(max-width:980px){.bars-plain.cinco{grid-template-columns:repeat(3,1fr);}}
+  @media(max-width:820px){.bars-plain{grid-template-columns:1fr 1fr;}}
+  @media(max-width:620px){.bars-plain.cinco{grid-template-columns:1fr 1fr;}}
+  @media(max-width:460px){.bars-plain,.bars-plain.cinco{grid-template-columns:1fr;}}
+
+  /* legenda */
+  .legend{display:flex;flex-wrap:wrap;gap:8px 20px;margin-top:22px;
+    padding-top:16px;border-top:1px solid var(--line);}
+  .legend span{font-family:var(--mono);font-size:12px;color:var(--ink-2);
+    display:inline-flex;align-items:center;gap:8px;}
+  .legend i{width:11px;height:11px;flex:none;border-radius:2px;}
+
+  /* barra empilhada 100% */
+  .stack{display:flex;height:46px;gap:2px;}
+  .stack div{display:grid;place-items:center;font-family:var(--mono);font-size:13px;
+    font-weight:600;color:#fff;}
+  .stack .a{background:var(--green-dark);}
+  .stack .b{background:var(--data-mute);color:var(--ink);}
+  .stack-lbl{display:flex;justify-content:space-between;gap:16px;margin-top:10px;
+    font-family:var(--mono);font-size:12px;color:var(--ink-2);}
+
+  /* escada */
+  .stairs{display:grid;grid-template-columns:repeat(4,1fr);gap:2px;align-items:end;
+    min-height:340px;min-width:520px;}
+  .step{display:flex;flex-direction:column;justify-content:flex-end;gap:0;}
+  .step .meta{padding:0 4px 12px;}
+  .step .k{font-family:var(--mono);font-size:11px;letter-spacing:.06em;text-transform:uppercase;
+    color:var(--muted);}
+  .step .t{font-size:14.5px;font-weight:600;line-height:1.25;margin-top:5px;letter-spacing:-.01em;}
+  .step .v{font-family:var(--mono);font-size:clamp(19px,2.6vw,26px);font-weight:600;
+    letter-spacing:-.02em;margin-top:8px;color:var(--ink);}
+  .step .blk{background:var(--data-mute);border-radius:4px 4px 0 0;}
+  .step:nth-child(1) .blk{background:color-mix(in srgb,var(--green) 34%,transparent);}
+  .step:nth-child(2) .blk{background:color-mix(in srgb,var(--green) 56%,transparent);}
+  .step:nth-child(3) .blk{background:color-mix(in srgb,var(--green) 78%,transparent);}
+  .step:nth-child(4) .blk{background:var(--green);}
+  .step:nth-child(4) .v{color:var(--green);}
+
+  /* curva */
+  .curve{width:100%;height:auto;display:block;min-width:520px;}
+  .curve .grid{stroke:var(--line);stroke-width:1;}
+  .curve .axis{stroke:var(--line-2);stroke-width:1;}
+  .curve .lbl{font-family:var(--mono);font-size:10.5px;fill:var(--muted);}
+  .curve .line{fill:none;stroke:var(--green);stroke-width:2;stroke-linejoin:round;stroke-linecap:round;}
+  .curve .line.thin{stroke-dasharray:4 4;opacity:.55;}
+  .curve .band{fill:var(--green);opacity:.09;}
+  .curve .dot{fill:var(--green);stroke:var(--paper);stroke-width:2;}
+
+  /* venn */
+  .venn{width:100%;height:auto;display:block;max-width:560px;margin:0 auto;}
+  .venn .cA{fill:var(--blue);opacity:.22;stroke:var(--blue);stroke-width:2;}
+  .venn .cB{fill:var(--green);opacity:.22;stroke:var(--green);stroke-width:2;}
+  .venn .vt{font-family:var(--mono);font-size:12px;fill:var(--ink-2);}
+  .venn .vn{font-family:var(--mono);font-size:26px;font-weight:600;fill:var(--ink);}
+  .venn .vs{font-size:11.5px;fill:var(--muted);font-family:var(--mono);}
+
+  /* callout / provocação */
+  .callout{margin-top:28px;border:1px solid var(--line);border-left:4px solid var(--yellow);
+    background:var(--surface);padding:24px 26px;}
+  #ato-2 .callout,#ato-4 .callout,#ato-6 .callout{background:var(--paper);}
+  .frentes.tres{grid-template-columns:repeat(3,1fr);}
+  @media(max-width:860px){.frentes.tres{grid-template-columns:1fr;}}
+  .callout .k{font-family:var(--mono);font-size:11.5px;letter-spacing:.09em;text-transform:uppercase;
+    color:var(--muted);}
+  .callout p{margin-top:10px;font-size:17px;line-height:1.55;color:var(--ink);max-width:60ch;}
+  .callout p b{color:var(--accent);}
+
+  /* ficha técnica — a transparência é parte do design, não apêndice */
+  .ficha{margin-top:22px;border-top:1px solid var(--line);padding-top:14px;
+    display:grid;gap:6px;}
+  .ficha div{display:grid;grid-template-columns:88px minmax(0,1fr);gap:12px;
+    font-family:var(--mono);font-size:11.5px;line-height:1.5;}
+  .ficha dt,.ficha .k{color:var(--muted);letter-spacing:.05em;text-transform:uppercase;}
+  .ficha .v{color:var(--ink-2);word-break:break-word;}
+  .ficha .v.alerta{color:var(--red);}
+  :root[data-theme="dark"] .ficha .v.alerta{color:#ff6b6b;}
+  :root[data-theme="dark"] .equipe .av{color:var(--green);}
+  @media (prefers-color-scheme:dark){:root:not([data-theme="light"]) .equipe .av{color:var(--green);}}
+  @media (prefers-color-scheme:dark){:root:not([data-theme="light"]) .ficha .v.alerta{color:#ff6b6b;}}
+  @media(max-width:560px){.ficha div{grid-template-columns:1fr;gap:2px;}}
+
+  /* ---------- navegação por teclado ---------- */
+  section,footer{scroll-margin-top:12px;}
+  .navpill{position:fixed;right:22px;bottom:22px;z-index:70;display:flex;align-items:center;gap:2px;
+    background:var(--surface);border:1px solid var(--line-2);border-radius:999px;padding:4px;
+    box-shadow:var(--shadow);font-family:var(--mono);}
+  .navpill button{appearance:none;background:transparent;border:0;cursor:pointer;color:var(--ink-2);
+    width:34px;height:34px;border-radius:999px;display:grid;place-items:center;font-size:15px;
+    line-height:1;transition:background .12s,color .12s;}
+  .navpill button:hover{background:var(--field);color:var(--ink);}
+  .navpill button[disabled]{opacity:.32;cursor:default;}
+  .navpill button[disabled]:hover{background:transparent;color:var(--ink-2);}
+  .navpill .pos{font-size:12px;color:var(--ink-2);padding:0 10px;white-space:nowrap;
+    font-variant-numeric:tabular-nums;}
+  .navpill .pos b{color:var(--ink);font-weight:600;}
+  .navpill .fim{display:none;font-size:10.5px;letter-spacing:.09em;text-transform:uppercase;
+    color:var(--green-dark);background:color-mix(in srgb,var(--green) 15%,transparent);
+    border-radius:999px;padding:3px 9px;margin-right:2px;}
+  .navpill[data-fim="1"] .fim{display:inline-block;}
+  .navhint{position:fixed;right:22px;bottom:68px;z-index:70;font-family:var(--mono);font-size:11.5px;
+    color:var(--muted);background:var(--surface);border:1px solid var(--line);border-radius:6px;
+    padding:7px 11px;box-shadow:var(--shadow);transition:opacity .4s;}
+  .navhint kbd{font-family:var(--mono);font-size:11px;background:var(--field);border:1px solid var(--line-2);
+    border-bottom-width:2px;border-radius:4px;padding:1px 5px;color:var(--ink-2);}
+  .navhint[hidden]{display:none;}
+  @media print{.navpill,.navhint{display:none;}}
+  @media(max-width:620px){.navhint{display:none;} .navpill{right:14px;bottom:14px;}}
+
+  /* tooltip */
+  #tip{position:fixed;z-index:80;pointer-events:none;opacity:0;transition:opacity .1s;
+    background:var(--ink);color:var(--paper);font-family:var(--mono);font-size:12px;
+    padding:7px 10px;border-radius:4px;max-width:240px;line-height:1.45;box-shadow:var(--shadow);}
+  #tip[data-on="1"]{opacity:1;}
+
+  /* rodapé */
+  footer{padding:56px 0 72px;}
+  footer .ft{display:grid;gap:8px;font-family:var(--mono);font-size:12.5px;color:var(--muted);}
+  footer a{color:var(--ink-2);}
+  footer h3{font-size:15px;font-weight:600;color:var(--ink);margin-bottom:6px;font-family:var(--sans);}
+  .divergencias{margin-top:26px;border:1px solid var(--line);background:var(--surface);}
+  .divergencias h3{padding:18px 22px 0;}
+  .divergencias table{border-collapse:collapse;width:100%;min-width:600px;font-size:13.5px;}
+  .divergencias .tw{overflow-x:auto;margin-top:12px;}
+  .divergencias th,.divergencias td{text-align:left;padding:11px 22px;border-top:1px solid var(--line);
+    vertical-align:top;}
+  .divergencias th{font-family:var(--mono);font-size:10.5px;letter-spacing:.07em;text-transform:uppercase;
+    color:var(--muted);font-weight:500;}
+  .divergencias td.a{font-family:var(--mono);font-size:12.5px;color:var(--ink-2);white-space:nowrap;}
+  .divergencias td.b{color:var(--ink-2);}
+  .divergencias td.b b{color:var(--ink);}
+
+  /* Revelação suave — enriquecimento, nunca requisito.
+     Sem a classe .js no <html> tudo já nasce visível: se o script falhar,
+     não carregar ou o ambiente não suportar IntersectionObserver, a página
+     continua legível por inteiro. */
+  .rv{opacity:1;transform:none;}
+  html.js .rv{opacity:0;transform:translateY(14px);transition:opacity .5s ease,transform .5s ease;}
+  html.js .rv.in{opacity:1;transform:none;}
+  @media (prefers-reduced-motion:reduce){html.js .rv{opacity:1;transform:none;}}
+</style>
+
+<div class="progress" role="presentation"><i id="prog"></i></div>
+
+<main>
+  <!-- ================= CAPA ================= -->
+  <section class="cover"><div class="wrap">
+    <p class="eyebrow">IFES · Campus Serra — DPPGE · balanço dos primeiros 6 meses de gestão</p>
+    <h1>Transparência: <span class="b">descobrindo o campus e seus impactos.</span></h1>
+    <p class="lede">Seis meses de gestão da Diretoria de Pesquisa, Pós-Graduação e Extensão.
+      Em vez de listar o que a diretoria fez, este balanço mostra o que o <b>campus</b> faz —
+      em quatro leituras dos dados reais: quem a extensão alcança, como pesquisa e extensão
+      se cruzam, o que acontece com quem passa por aqui, e onde está a nossa maior
+      oportunidade para 2027.</p>
+    <p class="lede" style="margin-top:16px">O trabalho destes seis meses foi tornar esses
+      números <b>encontráveis, auditáveis e abertos</b>. Por isso cada bloco aqui mostra a
+      própria fonte, a própria base e as próprias ressalvas: transparência não é o título
+      da apresentação, é o método dela.</p>
+
+    <nav class="toc">
+      <a href="#ato-1"><span class="k">01</span><span class="t">Extensão além dos muros</span></a>
+      <a href="#ato-2"><span class="k">02</span><span class="t">O fim do mito do pesquisador isolado</span></a>
+      <a href="#ato-3"><span class="k">03</span><span class="t">A escada real de crescimento</span></a>
+      <a href="#ato-4"><span class="k">04</span><span class="t">O fomento e o nosso desafio</span></a>
+      <a href="#gestao"><span class="k">05</span><span class="t">O que tornou este balanço possível</span></a>
+      <a href="#ato-6"><span class="k">06</span><span class="t">Escritório de Projetos</span></a>
+      <a href="#ato-7"><span class="k">07</span><span class="t">Visão 2027: crescer juntos</span></a>
+    </nav>
+  </div></section>
+
+  <!-- ================= ATO 1 ================= -->
+  <section class="act" id="ato-1"><div class="wrap">
+    <div class="head">
+      <span class="num">01</span>
+      <div>
+        <p class="eyebrow">Extensão</p>
+        <h2>Extensão além dos muros</h2>
+        <p class="lede">O campus alcançou <b>4.845 pessoas</b> com suas ações de extensão.
+          E não é um público qualquer: <b>44% de tudo o que atendemos tem menos de 18 anos</b>.
+          A nossa força está na formação de base — chegamos na criança e no adolescente
+          antes que o sistema decida por eles.</p>
+
+        <div class="fig rv">
+          <p class="cap">Público atendido por faixa etária</p>
+          <div class="hero-n">
+            <span class="v tnum">44%</span>
+            <span class="d">do público atendido pela extensão tem <b>menos de 18 anos</b>
+              — 3.475 de 7.938 atendimentos, ou 43,8% exatos.</span>
+          </div>
+          <div class="bars" id="bars-idade"></div>
+          <div class="bracket">
+            <span class="z"><span class="rule" style="width:44%"></span>
+              <span class="txt">menores de 18 anos · 3.475 · 43,8%</span></span>
+          </div>
+          <div class="legend">
+            <span><i style="background:var(--green)"></i>menores de 18 anos</span>
+            <span><i style="background:var(--data-mute)"></i>18 anos ou mais</span>
+          </div>
+          <div class="ficha">
+            <div><span class="k">Fonte</span><span class="v">/src/api/painel.json → impacto.idade · Painel de Extensão SRC</span></div>
+            <div><span class="k">Base</span><span class="v">7.938 atendimentos registrados. As 4.845 pessoas são <b>alunos únicos</b> — quem participou de mais de uma ação conta uma vez só ali, e uma vez por ação aqui. Os 44% se calculam sobre os atendimentos.</span></div>
+            <div><span class="k">Leitura</span><span class="v">Barras ordenadas por faixa etária, não por tamanho. Verde = menor de 18.</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div></section>
+
+  <!-- ================= ATO 2 ================= -->
+  <section class="act" id="ato-2"><div class="wrap">
+    <div class="head">
+      <span class="num">02</span>
+      <div>
+        <p class="eyebrow">Pesquisa × Extensão</p>
+        <h2>O fim do mito do pesquisador isolado</h2>
+        <p class="lede">O trabalho não acontece em bolhas: <b>78% dos coordenadores de pesquisa
+          do campus também fazem extensão</b>. E o relatório mostra o que isso não custa —
+          fazer extensão <b>não reduz o impacto científico</b> de quem faz. A excelência
+          científica caminha de mãos dadas com a transformação da comunidade.</p>
+
+        <div class="fig rv">
+          <p class="cap">Coordenadores de pesquisa que também coordenam extensão</p>
+          <svg class="venn" viewBox="0 0 560 300" role="img"
+               aria-label="Diagrama: 78% dos coordenadores de pesquisa também fazem extensão.">
+            <circle class="cB" cx="330" cy="150" r="128"/>
+            <circle class="cA" cx="212" cy="150" r="96"/>
+            <text class="vt" x="120" y="42" text-anchor="middle">Pesquisa</text>
+            <text class="vt" x="452" y="42" text-anchor="middle">Extensão</text>
+            <text class="vn" x="146" y="150" text-anchor="middle">22%</text>
+            <text class="vs" x="146" y="170" text-anchor="middle">só pesquisa</text>
+            <text class="vn" x="268" y="146" text-anchor="middle">78%</text>
+            <text class="vs" x="268" y="166" text-anchor="middle">fazem os dois</text>
+            <text class="vs" x="268" y="184" text-anchor="middle">sem perder FWCI</text>
+            <text class="vs" x="430" y="150" text-anchor="middle">757 extensionistas</text>
+          </svg>
+          <div class="legend">
+            <span><i style="background:var(--blue);opacity:.5"></i>coordenadores de pesquisa</span>
+            <span><i style="background:var(--green);opacity:.5"></i>extensionistas do campus</span>
+          </div>
+          <div class="ficha">
+            <div><span class="k">Fonte</span><span class="v">Relatório <b>Pesquisa × Extensão</b> · docs/relatorios/pesquisa-x-extensao.html</span></div>
+            <div><span class="k">Base</span><span class="v">Coordenadores de projetos de pesquisa do campus, cruzados com a base de extensionistas do SRC. FWCI mediano usado como controle de impacto científico.</span></div>
+            <div><span class="k">Leitura</span><span class="v alerta">Diagrama esquemático: as áreas dos círculos não são proporcionais aos conjuntos. Só o 78% e o 22% são valores medidos.</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div></section>
+
+  <!-- ================= ATO 3 ================= -->
+  <section class="act" id="ato-3"><div class="wrap">
+    <div class="head">
+      <span class="num">03</span>
+      <div>
+        <p class="eyebrow">Egressos</p>
+        <h2>A escada real de crescimento</h2>
+        <p class="lede">O destino final do esforço é mudar vidas. <b>100% dos egressos analisados
+          seguem na área de TI</b>, e a renda mediana da coorte <b>multiplicou por 7,2</b> entre o
+          primeiro emprego e hoje. A escada começa numa bolsa de projeto dentro do campus
+          e chega ao nível sênior — degrau por degrau, com dados de gente real.</p>
+
+        <div class="fig rv">
+          <p class="cap">Os quatro degraus — renda mediana em R$ de 2026</p>
+          <div class="figscroll">
+            <div class="stairs" id="stairs"></div>
+          </div>
+          <div class="ficha">
+            <div><span class="k">Fonte</span><span class="v">/egressos/api/coorte.json e /egressos/api/coorte/serie-por-experiencia.json</span></div>
+            <div><span class="k">Base</span><span class="v">Coorte de 50 egressos, 49 com série salarial reconstruída. 49 de 49 seguem em TI. Bolsa registrada em 23 dos 49 — o degrau 1 vale para quem teve bolsa.</span></div>
+            <div><span class="k">Leitura</span><span class="v">Alturas proporcionais ao valor. Multiplicador 7,2× = mediana de hoje (R$ 17.073) sobre a mediana do primeiro emprego (R$ 2.378). Pela média dos multiplicadores individuais dá 8,0×.</span></div>
+          </div>
+        </div>
+
+        <div class="fig rv">
+          <p class="cap">A curva completa — renda mediana por ano de experiência</p>
+          <div class="figscroll">
+            <svg class="curve" id="curve" viewBox="0 0 900 320" role="img"
+                 aria-label="Curva de renda mediana por anos de experiência, de R$ 2.417 no ano zero a cerca de R$ 19 mil após 10 anos."></svg>
+          </div>
+          <div class="legend">
+            <span><i style="background:var(--green)"></i>mediana da coorte</span>
+            <span><i style="background:var(--green);opacity:.25"></i>faixa p25–p75</span>
+            <span><i style="background:none;border-top:2px dashed var(--green);height:0;opacity:.6;width:16px"></i>tracejado = menos de 10 egressos no ponto</span>
+          </div>
+          <div class="ficha">
+            <div><span class="k">Fonte</span><span class="v">/egressos/api/coorte/serie-por-experiencia.json · campo <b>trajetoria_real</b></span></div>
+            <div><span class="k">Base</span><span class="v">Cada ponto agrega os egressos que tinham aquele tempo de carreira. O n cai no fim da curva — passe o mouse para ver quantos sustentam cada ponto.</span></div>
+            <div><span class="k">Leitura</span><span class="v alerta">Estudo experimental, dados preliminares e anonimizados. A cauda acima de 13 anos apoia-se em 14 egressos ou menos.</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div></section>
+
+  <!-- ================= ATO 4 ================= -->
+  <section class="act" id="ato-4"><div class="wrap">
+    <div class="head">
+      <span class="num">04</span>
+      <div>
+        <p class="eyebrow">Fomento</p>
+        <h2>A verdade sobre o fomento — e o nosso desafio</h2>
+        <p class="lede">O corpo docente é uma potência: a captação do campus está na ordem de
+          <b>dezenas de milhões de reais</b>, recurso que volta em equipamento, bolsa e
+          laboratório. E há um fato que precisa ser dito em voz alta:
+          <b>70% do orçamento FAPES do campus está concentrado em 5 coordenadores</b>.</p>
+
+        <div class="fig rv">
+          <p class="cap">Concentração do orçamento FAPES · 99 projetos</p>
+          <div class="stack">
+            <div class="a" style="flex:70">70% · top 5</div>
+            <div class="b" style="flex:30">30% · demais</div>
+          </div>
+          <div class="stack-lbl"><span>5 coordenadores</span><span>todos os outros</span></div>
+          <div class="bars" id="bars-conc" style="margin-top:30px"></div>
+          <div class="legend">
+            <span><i style="background:var(--green-dark)"></i>entre os 5 maiores</span>
+            <span><i style="background:var(--data-mute)"></i>demais coordenadores</span>
+          </div>
+          <div class="ficha">
+            <div><span class="k">Fonte</span><span class="v">Relatório <b>Captação de Projetos — FAPES + FACTO</b> · docs/relatorios/captacao-projetos.html</span></div>
+            <div><span class="k">Base</span><span class="v">Percentual do orçamento FAPES por coordenador. Não inclui FACTO, onde a concentração é ainda maior (44% num único coordenador, universo pequeno).</span></div>
+            <div><span class="k">Leitura</span><span class="v">Coordenadores anonimizados nesta apresentação. Os nomes estão no relatório de origem, que é público.</span></div>
+            <div><span class="k">Ressalva</span><span class="v alerta">O relatório de captação carrega aviso de estudo experimental — dados preliminares, sujeitos a revisão. O valor total é declarado como <b>ordem de grandeza</b> (~R$ 60 mi, dezenas de milhões), não como cifra apurada.</span></div>
+          </div>
+        </div>
+
+        <div class="callout rv">
+          <p class="k">A provocação para 2027</p>
+          <p>Concentração não é acusação — é <b>expertise instalada</b>. Cinco pessoas
+            aprenderam a captar num nível que o campus inteiro pode aprender. O convite é
+            transformar esse conhecimento em <b>grupos colaborativos de submissão</b>:
+            cada projeto grande puxando um coordenador novo junto. Multiplicar não é
+            dividir o que já existe — é fazer o próximo edital caber em mais gente.</p>
+        </div>
+      </div>
+    </div>
+  </div></section>
+
+  <!-- ================= O QUE SUSTENTA O BALANÇO ================= -->
+  <section class="act" id="gestao"><div class="wrap">
+    <div class="head">
+      <span class="num">05</span>
+      <div>
+        <p class="eyebrow">Os primeiros seis meses</p>
+        <h2>O que tornou este balanço possível</h2>
+        <p class="lede">Nenhum número desta apresentação foi produzido para ela. Todos vieram
+          de painéis que já rodam, com API aberta e código público. O trabalho da gestão
+          nestes seis meses foi <b>construir a infraestrutura que torna o campus legível</b> —
+          para a diretoria, para os docentes e para quem estiver de fora.</p>
+
+        <div class="fig rv">
+          <p class="cap">Infraestrutura de dados em produção</p>
+          <div class="bars-plain">
+            <div class="pl"><b class="tnum">6</b><span>portais em produção</span>
+              <em>extensão, editais, egressos, diretoria, documentos e pesquisa</em></div>
+            <div class="pl"><b class="tnum">12</b><span>painéis analíticos</span>
+              <em>de ROI e bibliometria a elegibilidade em edital</em></div>
+            <div class="pl"><b class="tnum">100%</b><span>com API aberta</span>
+              <em>JSON estático, licença CC BY 4.0, sem login</em></div>
+            <div class="pl"><b class="tnum">git</b><span>atas e decisões versionadas</span>
+              <em>registro público e rastreável desde 27/02/2026</em></div>
+          </div>
+          <div class="ficha">
+            <div><span class="k">Fonte</span><span class="v">github.com/ifesserra-lab · catálogo em web/src/lib/reports.ts · docs/atas e docs/decisoes</span></div>
+            <div><span class="k">Leitura</span><span class="v">Portais contados são os listados como “em produção” na home do laboratório. Painéis incluem os marcados como experimentais.</span></div>
+          </div>
+        </div>
+
+        <div class="callout rv" style="border-left-color:var(--green)">
+          <p class="k">O que isso muda</p>
+          <p>Antes, responder “quantas pessoas a extensão alcançou?” era um pedido de
+            levantamento. Agora é uma <b>URL</b>. É essa diferença que permite uma
+            apresentação institucional declarar as próprias ressalvas em vez de escondê-las —
+            e é ela que sustenta a provocação de 2027.</p>
+        </div>
+      </div>
+    </div>
+  </div></section>
+
+  <!-- ================= ATO 6 · APOIO REAL ================= -->
+  <section class="act" id="ato-6"><div class="wrap">
+    <div class="head">
+      <span class="num">06</span>
+      <div>
+        <p class="eyebrow">Apoio real</p>
+        <h2>Escritório de Projetos e Portal de Editais</h2>
+        <p class="lede">Nosso objetivo é facilitar: <b>tirar a burocracia do caminho de quem
+          deseja transformar ideias em projetos reais</b>. Para isso estruturamos uma equipe
+          dedicada e humana, pronta para dar o suporte necessário para você tirar o seu
+          projeto do papel.</p>
+
+        <div class="fig rv">
+          <p class="cap">A equipe do Escritório de Projetos</p>
+          <div class="equipe">
+            <div class="pe"><span class="av">L</span><span class="nm">Luciano</span></div>
+            <div class="pe"><span class="av">S</span><span class="nm">Sara</span></div>
+            <div class="pe"><span class="av">L</span><span class="nm">Lorena</span></div>
+            <div class="pe"><span class="av">R</span><span class="nm">Renata</span></div>
+            <div class="pe"><span class="av">M</span><span class="nm">Michele</span></div>
+          </div>
+          <p class="equipe-nota">Procure qualquer uma delas. O escritório existe para carregar
+            a burocracia — para que o docente carregue a pesquisa.</p>
+        </div>
+
+        <div class="fig rv">
+          <p class="cap">O volume que já passa pelas nossas mãos</p>
+          <div class="bars-plain cinco">
+            <div class="pl"><b class="tnum">58</b><span>editais catalogados</span>
+              <em>base completa em JSON aberto, baixável num arquivo só</em></div>
+            <div class="pl"><b class="tnum">56</b><span>abertos agora</span>
+              <em>chamadas vigentes no Portal neste momento</em></div>
+            <div class="pl"><b class="tnum">99</b><span>projetos FAPES</span>
+              <em>captados pelo campus ao longo dos anos</em></div>
+            <div class="pl"><b class="tnum">34</b><span>projetos FACTO</span>
+              <em>coordenados pelo campus · 54 com participação</em></div>
+            <div class="pl"><b class="tnum">201</b><span>ações de extensão</span>
+              <em>142 ativas, todas rastreáveis por ação e por pessoa</em></div>
+          </div>
+          <div class="ficha">
+            <div><span class="k">Fonte</span><span class="v">Portal de Editais (páginas /dados e inicial) · relatório de Captação FAPES + FACTO · /src/api/painel.json</span></div>
+            <div><span class="k">Base</span><span class="v">Editais: 58 no pacote de dados abertos, 56 marcados como ativos na data desta apresentação — o número de abertos muda todo dia. Projetos FAPES e FACTO são acumulados históricos, não do semestre.</span></div>
+            <div><span class="k">Leitura</span><span class="v">FACTO: 34 projetos com coordenação de docente do campus e 54 com participação do campus — os conjuntos se sobrepõem e não devem ser somados.</span></div>
+          </div>
+        </div>
+
+        <div class="fig rv">
+          <p class="cap">Por que o escritório existe — a oportunidade nos dados</p>
+          <div class="hero-n">
+            <span class="v tnum">107</span>
+            <span class="d">das <b>142 ações ativas</b> de extensão não têm vínculo de
+              fomento registrado — projeto que já funciona e nunca foi a edital.</span>
+          </div>
+          <div class="bars" id="bars-fomento"></div>
+          <div class="legend">
+            <span><i style="background:var(--yellow)"></i>sem vínculo de fomento</span>
+            <span><i style="background:var(--data-mute)"></i>com fonte de fomento</span>
+          </div>
+          <div class="ficha">
+            <div><span class="k">Fonte</span><span class="v">/src/api/painel.json → visao_geral.fomento</span></div>
+            <div><span class="k">Base</span><span class="v">142 ações ativas com fonte de fomento declarada. “Sem vínculo” inclui a ação que não buscou recurso e a ação cujo vínculo não foi registrado no sistema.</span></div>
+            <div><span class="k">Leitura</span><span class="v">Não é diagnóstico de má gestão — é o estoque de projeto pronto que o escritório pode ajudar a levar a edital.</span></div>
+          </div>
+        </div>
+
+        <div class="callout rv" style="border-left-color:var(--blue)">
+          <p class="k">Portal de Editais</p>
+          <p>As chamadas de pesquisa, extensão e fomento reunidas e filtráveis num só lugar,
+            com coleta automatizada e sempre atualizada. Ninguém mais precisa descobrir
+            edital por e-mail encaminhado.
+            <b><a href="https://ifesserra-lab.github.io/portal_edital/">ifesserra-lab.github.io/portal_edital</a></b></p>
+        </div>
+      </div>
+    </div>
+  </div></section>
+
+  <!-- ================= ATO 7 · VISÃO 2027 ================= -->
+  <section class="act" id="ato-7"><div class="wrap">
+    <div class="head">
+      <span class="num">07</span>
+      <div>
+        <p class="eyebrow">Visão 2027</p>
+        <h2>Crescer juntos</h2>
+        <p class="lede">Os seis movimentos anteriores mostram um campus que já entrega.
+          O próximo ciclo é sobre <b>fazer isso em conjunto</b> — usar os dados e tudo o que
+          aprendemos este ano para planejar um 2027 sistêmico.</p>
+
+        <div class="fig rv">
+          <p class="cap">Três passos</p>
+          <div class="frentes tres">
+            <div class="fr">
+              <span class="n">01</span>
+              <h3>Espaço de Projetos Colaborativos</h3>
+              <p>Nosso próximo grande passo é criar um <b>ambiente físico e estruturado para
+                unir talentos</b>: um local onde grupos de pesquisa, núcleos e grupos de
+                extensão possam convergir ideias, colaborar e executar grandes projetos
+                em conjunto.</p>
+              <span class="ind">responde à concentração do ato 04</span>
+            </div>
+            <div class="fr">
+              <span class="n">02</span>
+              <h3>Integração total do campus</h3>
+              <p>Vamos mergulhar fundo para entender e integrar cada vez mais a força da
+                nossa <b>Incubadora</b> e da nossa <b>Pós-Graduação</b> ao restante do
+                ecossistema.</p>
+              <span class="ind">o campus como um sistema, não como setores</span>
+            </div>
+            <div class="fr">
+              <span class="n">03</span>
+              <h3>Um 2027 sistêmico</h3>
+              <p>Usar os dados e tudo o que aprendemos este ano para planejar um 2027 em que
+                o campus atue cada vez mais em união, <b>multiplicando os resultados que
+                vocês já entregam hoje à sociedade</b>.</p>
+              <span class="ind">planejamento com base no que está medido</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout rv" style="border-left-color:var(--green)">
+          <p class="k">O convite</p>
+          <p>Nada aqui foi feito pela diretoria: <b>4.845 pessoas alcançadas, 78% de
+            pesquisadores que também fazem extensão, egressos que multiplicaram a renda
+            por sete</b> — isso é trabalho de vocês. O que propomos para 2027 é que o
+            próximo ciclo dependa de <b>muita gente</b>, e não da persistência de poucos.</p>
+        </div>
+      </div>
+    </div>
+  </div></section>
+
+  <!-- ================= RODAPÉ ================= -->
+  <footer><div class="wrap">
+    <p class="eyebrow">Procedência</p>
+    <div class="divergencias">
+      <h3>Onde esta apresentação diverge do briefing — e por quê</h3>
+      <div class="tw"><table>
+        <thead><tr><th>No briefing</th><th>Aqui</th><th>Motivo</th></tr></thead>
+        <tbody>
+          <tr><td class="a">44% de 4.845</td><td class="a">43,8% de 7.938</td>
+            <td class="b">Os 44% se calculam sobre <b>atendimentos</b> (7.938), não sobre pessoas únicas (4.845). O percentual está certo; a base é outra.</td></tr>
+          <tr><td class="a">bolsa de R$ 800</td><td class="a">R$ 813 – R$ 1.316</td>
+            <td class="b">R$ 813 é a <b>menor</b> bolsa registrada; a mediana de quem teve bolsa é R$ 1.316. E só 23 dos 49 egressos tiveram bolsa.</td></tr>
+          <tr><td class="a">sênior R$ 14.608</td><td class="a">R$ 17.073 hoje</td>
+            <td class="b">R$ 14.608 corresponde ao patamar de <b>8 anos de experiência</b> (R$ 14.664 na série). A mediana atual da coorte é maior.</td></tr>
+          <tr><td class="a">renda × 8,1</td><td class="a">× 7,2 (mediana)</td>
+            <td class="b">7,2× é mediana sobre mediana. A <b>média</b> dos multiplicadores individuais dá 8,0×. Os três números do briefing eram incompatíveis entre si: 800 × 8,1 = 6.480, não 14.608.</td></tr>
+          <tr><td class="a">R$ 60 mi captados</td><td class="a">dezenas de milhões</td>
+            <td class="b">O relatório de origem declara <b>ordem de grandeza</b>, não cifra apurada, e carrega aviso de estudo experimental. Afirmar “captamos R$ 60 milhões” contradiz a nossa própria metodologia.</td></tr>
+          <tr><td class="a">70,1% do recurso</td><td class="a">70% do FAPES</td>
+            <td class="b">A concentração medida é do <b>orçamento FAPES</b>. O total captado inclui FACTO, que não entra nessa conta.</td></tr>
+        </tbody>
+      </table></div>
+    </div>
+
+    <div class="ft" style="margin-top:32px">
+      <span>Dados: painel de Extensão SRC · estudo de egressos · relatórios de captação e Pesquisa × Extensão — IFES Campus Serra.</span>
+      <span>Séries de egressos e captação são <b>estudos experimentais</b>: dados preliminares, anonimizados, sujeitos a revisão.</span>
+      <span>APIs abertas em <a href="https://ifesserra-lab.github.io/">ifesserra-lab.github.io</a> · dados CC BY 4.0.</span>
+    </div>
+  </div></footer>
+</main>
+
+<nav class="navpill" aria-label="Navegação entre seções">
+  <button id="nav-prev" type="button" aria-label="Seção anterior" title="Seção anterior (↑)">↑</button>
+  <span class="fim">última</span>
+  <span class="pos" aria-live="polite"><b id="nav-i">1</b> / <span id="nav-n">9</span></span>
+  <button id="nav-next" type="button" aria-label="Próxima seção" title="Próxima seção (↓)">↓</button>
+</nav>
+<div class="navhint" id="navhint"><kbd>↑</kbd> <kbd>↓</kbd> para navegar · <kbd>Home</kbd> <kbd>End</kbd></div>
+
+<div id="tip" role="status" aria-live="polite"></div>
+
+<script>
+  /* ---------- dados verificados nas APIs ---------- */
+  var IDADE = [
+    ['menor de 15',  825, true],
+    ['15–17',       2650, true],
+    ['18–24',       2594, false],
+    ['25–34',        802, false],
+    ['35–59',        999, false],
+    ['60+',           68, false]
+  ];
+  var TOTAL_IDADE = 7938;
+
+  var DEGRAUS = [
+    ['degrau 1','Bolsa de projeto no campus', 1316, 'mediana das bolsas registradas · 23 dos 49 egressos'],
+    ['degrau 2','Primeiro emprego',           2417, 'mediana no ano 0 de carreira · n = 44'],
+    ['degrau 3','Meio de carreira',          10086, 'mediana com 5 anos de experiência · n = 43'],
+    ['degrau 4','Sênior, hoje',              17073, 'mediana atual da coorte · n = 49']
+  ];
+
+  var CONC = [
+    ['Coord. 1', 24, true],  ['Coord. 2', 14, true],  ['Coord. 3', 12, true],
+    ['Coord. 4', 12, true],  ['Coord. 5',  8, true],  ['Coord. 6',  6, false],
+    ['Coord. 7',  3, false], ['Coord. 8',  2, false], ['demais',   19, false]
+  ];
+
+  var CURVA = [
+    [0,813,14056,2417,44],   [1,765,7028,2597,42],    [2,892,11214,2916,40],
+    [3,3422,16945,7203,41],  [4,3091,17132,8092,42],  [5,3422,20824,10086,43],
+    [6,5473,24037,12514,43], [7,5584,25380,13888,44], [8,5467,26257,14664,41],
+    [9,8923,36390,16734,33], [10,8595,35161,18623,27],[11,7567,34294,18194,26],
+    [12,8653,38137,19372,18],[13,8876,37042,17988,14],[14,11525,41413,19722,11],
+    [15,11977,35403,18870,6],[16,13172,32054,20878,3],[17,12631,31359,19055,3]
+  ];
+
+  var nf = new Intl.NumberFormat('pt-BR');
+  var brl = function(v){ return 'R$ ' + nf.format(v); };
+  var pct = function(v){ return v.toFixed(1).replace('.', ',') + '%'; };
+
+  /* ---------- tooltip compartilhado ---------- */
+  var tip = document.getElementById('tip');
+  function bindTip(el, html){
+    el.addEventListener('pointerenter', function(){ tip.innerHTML = html; tip.dataset.on = '1'; });
+    el.addEventListener('pointermove', function(e){
+      var x = Math.min(e.clientX + 14, window.innerWidth - tip.offsetWidth - 10);
+      tip.style.left = x + 'px';
+      tip.style.top = Math.max(10, e.clientY - tip.offsetHeight - 12) + 'px';
+    });
+    el.addEventListener('pointerleave', function(){ tip.dataset.on = '0'; });
+  }
+
+  /* ---------- ato 1: faixas etárias ---------- */
+  (function(){
+    var host = document.getElementById('bars-idade');
+    var maxPct = Math.max.apply(null, IDADE.map(function(r){ return r[1] / TOTAL_IDADE * 100; }));
+    IDADE.forEach(function(r){
+      var p = r[1] / TOTAL_IDADE * 100;
+      var row = document.createElement('div');
+      row.className = 'bar';
+      row.dataset.hl = r[2] ? '1' : '0';
+      row.innerHTML = '<span class="lbl">' + r[0] + '</span>' +
+        '<span class="track"><span class="fill"></span></span>' +
+        '<span class="val tnum">' + pct(p) + '</span>';
+      host.appendChild(row);
+      row.querySelector('.fill').dataset.w = (p / maxPct * 100) + '%';
+      bindTip(row, '<b>' + r[0] + '</b><br>' + nf.format(r[1]) + ' atendimentos<br>' +
+        pct(p) + ' do total');
+    });
+  })();
+
+  /* ---------- ato 3: escada ---------- */
+  (function(){
+    var host = document.getElementById('stairs');
+    var max = DEGRAUS[DEGRAUS.length - 1][2];
+    DEGRAUS.forEach(function(d){
+      var h = Math.max(16, d[2] / max * 214);
+      var col = document.createElement('div');
+      col.className = 'step';
+      col.innerHTML = '<div class="meta"><div class="k">' + d[0] + '</div>' +
+        '<div class="t">' + d[1] + '</div>' +
+        '<div class="v tnum">' + brl(d[2]) + '</div></div>' +
+        '<div class="blk" style="height:0"></div>';
+      host.appendChild(col);
+      col.querySelector('.blk').dataset.h = h + 'px';
+      bindTip(col, '<b>' + d[1] + '</b><br>' + brl(d[2]) + '/mês<br>' + d[3]);
+    });
+  })();
+
+  /* ---------- ato 3: curva ---------- */
+  (function(){
+    var svg = document.getElementById('curve');
+    var W = 900, H = 320, ML = 62, MR = 20, MT = 18, MB = 40;
+    var pw = W - ML - MR, ph = H - MT - MB;
+    var maxY = 42000, maxX = 17;
+    var X = function(e){ return ML + e / maxX * pw; };
+    var Y = function(v){ return MT + ph - v / maxY * ph; };
+    var ns = 'http://www.w3.org/2000/svg';
+    var add = function(tag, attrs, txt){
+      var el = document.createElementNS(ns, tag);
+      for (var k in attrs) el.setAttribute(k, attrs[k]);
+      if (txt != null) el.textContent = txt;
+      svg.appendChild(el);
+      return el;
+    };
+
+    [0, 10000, 20000, 30000, 40000].forEach(function(v){
+      add('line', {class: 'grid', x1: ML, x2: W - MR, y1: Y(v), y2: Y(v)});
+      add('text', {class: 'lbl', x: ML - 10, y: Y(v) + 4, 'text-anchor': 'end'},
+        v === 0 ? '0' : (v / 1000) + ' mil');
+    });
+    add('line', {class: 'axis', x1: ML, x2: W - MR, y1: Y(0), y2: Y(0)});
+    [0, 3, 6, 9, 12, 15, 17].forEach(function(e){
+      add('text', {class: 'lbl', x: X(e), y: H - 14, 'text-anchor': 'middle'}, e + ' anos');
+    });
+
+    var band = CURVA.map(function(r){ return X(r[0]) + ',' + Y(r[2]); })
+      .concat(CURVA.slice().reverse().map(function(r){ return X(r[0]) + ',' + Y(r[1]); }));
+    add('polygon', {class: 'band', points: band.join(' ')});
+
+    var solid = CURVA.filter(function(r){ return r[4] >= 10; });
+    var thin  = CURVA.filter(function(r){ return r[4] < 10; });
+    var join  = CURVA.filter(function(r){ return r[4] >= 10; }).slice(-1).concat(thin);
+    add('path', {class: 'line', d: 'M' + solid.map(function(r){ return X(r[0]) + ' ' + Y(r[3]); }).join(' L')});
+    if (join.length > 1)
+      add('path', {class: 'line thin', d: 'M' + join.map(function(r){ return X(r[0]) + ' ' + Y(r[3]); }).join(' L')});
+
+    CURVA.forEach(function(r){
+      var c = add('circle', {class: 'dot', cx: X(r[0]), cy: Y(r[3]), r: r[4] >= 10 ? 4.5 : 3.5});
+      var hit = add('circle', {cx: X(r[0]), cy: Y(r[3]), r: 15, fill: 'transparent'});
+      bindTip(hit, '<b>' + r[0] + ' ano(s) de carreira</b><br>mediana ' + brl(r[3]) +
+        '<br>p25–p75 ' + brl(r[1]) + ' – ' + brl(r[2]) + '<br>' + r[4] + ' egressos no ponto' +
+        (r[4] < 10 ? '<br>— amostra pequena' : ''));
+      c.setAttribute('pointer-events', 'none');
+    });
+  })();
+
+  /* ---------- ato 4: concentração ---------- */
+  (function(){
+    var host = document.getElementById('bars-conc');
+    var max = 24;
+    CONC.forEach(function(r){
+      var row = document.createElement('div');
+      row.className = 'bar';
+      row.dataset.hl = r[2] ? '1' : '0';
+      row.innerHTML = '<span class="lbl">' + r[0] + '</span>' +
+        '<span class="track"><span class="fill"></span></span>' +
+        '<span class="val tnum">' + r[1] + '%</span>';
+      if (r[2]) row.querySelector('.fill').style.background = 'var(--green-dark)';
+      host.appendChild(row);
+      row.querySelector('.fill').dataset.w = (r[1] / max * 100) + '%';
+      bindTip(row, '<b>' + r[0] + '</b><br>' + r[1] + '% do orçamento FAPES' +
+        (r[2] ? '<br>entre os 5 maiores' : ''));
+    });
+  })();
+
+  /* ---------- ato 6: fomento das ações de extensão ---------- */
+  (function(){
+    var host = document.getElementById('bars-fomento');
+    if (!host) return;
+    var FOM = [
+      ['sem vínculo', 107, true], ['PAEX-IFES', 29, false], ['PRONATEC', 3, false],
+      ['MULHERES MIL', 2, false], ['FAPES', 1, false]
+    ];
+    var tot = FOM.reduce(function(a, r){ return a + r[1]; }, 0);
+    var max = 107;
+    FOM.forEach(function(r){
+      var p = r[1] / tot * 100;
+      var row = document.createElement('div');
+      row.className = 'bar';
+      row.dataset.hl = r[2] ? '1' : '0';
+      row.innerHTML = '<span class="lbl">' + r[0] + '</span>' +
+        '<span class="track"><span class="fill"></span></span>' +
+        '<span class="val tnum">' + r[1] + '</span>';
+      if (r[2]) row.querySelector('.fill').style.background = 'var(--yellow)';
+      host.appendChild(row);
+      row.querySelector('.fill').dataset.w = (r[1] / max * 100) + '%';
+      bindTip(row, '<b>' + r[0] + '</b><br>' + r[1] + ' de ' + tot + ' ações ativas<br>' +
+        pct(p) + ' do total');
+    });
+  })();
+
+  /* ---------- navegação por teclado entre as seções ---------- */
+  (function(){
+    var paradas = Array.prototype.slice.call(
+      document.querySelectorAll('section.cover, section.act, footer'));
+    if (!paradas.length) return;
+
+    var elI = document.getElementById('nav-i');
+    var elN = document.getElementById('nav-n');
+    var bPrev = document.getElementById('nav-prev');
+    var bNext = document.getElementById('nav-next');
+    var hint = document.getElementById('navhint');
+    var atual = 0;
+    elN.textContent = paradas.length;
+
+    var suave = !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    function pinta(){
+      elI.textContent = atual + 1;
+      bPrev.disabled = atual === 0;
+      bNext.disabled = atual === paradas.length - 1;
+    }
+    function vai(i){
+      atual = Math.max(0, Math.min(paradas.length - 1, i));
+      paradas[atual].scrollIntoView({behavior: suave ? 'smooth' : 'auto', block: 'start'});
+      pinta();
+      if (hint && !hint.hidden){ hint.style.opacity = '0'; setTimeout(function(){ hint.hidden = true; }, 400); }
+    }
+
+    /* qual seção domina a tela agora — mantém o contador certo no scroll livre */
+    var barra = document.getElementById('prog');
+    var pilula = document.querySelector('.navpill');
+    function preenche(){
+      var rolavel = document.documentElement.scrollHeight - window.innerHeight;
+      /* página que cabe inteira na tela já está 100% lida */
+      var p = rolavel > 4 ? window.scrollY / rolavel : 1;
+      p = Math.max(0, Math.min(1, p));
+      if (barra) barra.style.width = (p * 100).toFixed(2) + '%';
+      if (pilula) pilula.dataset.fim = (p > 0.92 || atual === paradas.length - 1) ? '1' : '0';
+    }
+
+    var pendente = false;
+    function sincroniza(){
+      if (pendente) return;
+      pendente = true;
+      requestAnimationFrame(function(){
+        pendente = false;
+        var alvo = window.innerHeight * 0.32, melhor = 0, dist = Infinity;
+        paradas.forEach(function(el, i){
+          var d = Math.abs(el.getBoundingClientRect().top - alvo);
+          if (d < dist){ dist = d; melhor = i; }
+        });
+        if (melhor !== atual){ atual = melhor; pinta(); }
+        preenche();
+      });
+    }
+    window.addEventListener('scroll', sincroniza, {passive: true});
+    window.addEventListener('resize', sincroniza, {passive: true});
+
+    bPrev.addEventListener('click', function(){ vai(atual - 1); });
+    bNext.addEventListener('click', function(){ vai(atual + 1); });
+
+    var AVANCA = {ArrowDown: 1, ArrowRight: 1, PageDown: 1, ' ': 1, j: 1, n: 1};
+    var VOLTA  = {ArrowUp: 1, ArrowLeft: 1, PageUp: 1, k: 1, p: 1};
+
+    document.addEventListener('keydown', function(e){
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      var alvo = e.target;
+      /* não sequestrar teclas de quem está digitando ou usando um controle */
+      if (alvo && (alvo.isContentEditable ||
+          /^(INPUT|TEXTAREA|SELECT|BUTTON|A)$/.test(alvo.tagName))) return;
+
+      if (AVANCA[e.key]){ e.preventDefault(); vai(atual + 1); }
+      else if (VOLTA[e.key]){ e.preventDefault(); vai(atual - 1); }
+      else if (e.key === 'Home'){ e.preventDefault(); vai(0); }
+      else if (e.key === 'End'){ e.preventDefault(); vai(paradas.length - 1); }
+    });
+
+    pinta();
+    preenche();
+    /* a dica some sozinha depois de um tempo, mesmo sem uso */
+    if (hint) setTimeout(function(){
+      hint.style.opacity = '0'; setTimeout(function(){ hint.hidden = true; }, 400);
+    }, 7000);
+  })();
+
+  /* ---------- revelação: as barras só crescem quando o bloco entra na tela ---------- */
+  (function(){
+    var desenha = function(root){
+      root.querySelectorAll('.fill[data-w]').forEach(function(el){ el.style.width = el.dataset.w; });
+      root.querySelectorAll('.blk[data-h]').forEach(function(el){ el.style.height = el.dataset.h; });
+    };
+    var els = document.querySelectorAll('.rv');
+    var tudo = function(){ els.forEach(function(e){ e.classList.add('in'); }); desenha(document); };
+    if (!('IntersectionObserver' in window) ||
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches){
+      tudo();
+      return;
+    }
+    document.documentElement.classList.add('js');
+    /* rede de segurança: se por qualquer motivo o observer não disparar,
+       nada fica invisível — 2s depois a página se revela sozinha. */
+    setTimeout(tudo, 2000);
+    var io = new IntersectionObserver(function(entries){
+      entries.forEach(function(en){
+        if (!en.isIntersecting) return;
+        en.target.classList.add('in');
+        desenha(en.target);
+        io.unobserve(en.target);
+      });
+    }, {rootMargin: '0px 0px -8% 0px'});
+    els.forEach(function(e){ io.observe(e); });
+  })();
+</script>
+
+</body>
+</html>

--- a/web/src/lib/reports.ts
+++ b/web/src/lib/reports.ts
@@ -19,6 +19,12 @@ export type Report = {
 
 export const reports: Report[] = [
   {
+    slug: 'balanco-2026', titulo: 'Balanço de Gestão — 6 meses', tag: 'Apresentação · 2026',
+    resumo: 'A apresentação institucional dos primeiros seis meses de gestão, em sete movimentos.',
+    descricao: 'Extensão, pesquisa × extensão, egressos, fomento, infraestrutura de dados, Escritório de Projetos e visão 2027. Navegável por teclado; cada bloco declara fonte, base e ressalvas.',
+    status: 'ok', path: 'relatorios/balanco-2026.html', spark: 'area',
+  },
+  {
     slug: 'campus-serra', titulo: 'Extensão — Campus Serra (SRC)', tag: 'Extensão · SRC',
     resumo: 'Tudo o que o campus faz de extensão, num painel navegável por ação, atividade e pessoa.',
     descricao: '201 ações, 525 atividades e 757 extensionistas. Busca, jornada do formado, pendências e dados abertos (JSON + llms.txt).',


### PR DESCRIPTION
Apresentação institucional da DPPGE — **"Transparência: descobrindo o campus e seus impactos"** — construída sobre as APIs abertas do campus, não sobre números redigitados.

Publicada em `docs/relatorios/balanco-2026.html` (SSOT). O `prebuild` copia para `web/public/relatorios/` e a entrada foi registrada como primeira do catálogo em `web/src/lib/reports.ts`.

Após o merge: **/diretoria/relatorios/balanco-2026.html**

## Sete movimentos

| | | Visual |
|---|---|---|
| 01 | Extensão além dos muros | proporção por faixa etária, menores de 18 destacados |
| 02 | O fim do mito do pesquisador isolado | diagrama de interseção 78% / 22% |
| 03 | A escada real de crescimento | 4 degraus + a curva completa por ano de experiência |
| 04 | A verdade sobre o fomento | concentração 70/30 + ranking anonimizado |
| 05 | O que tornou este balanço possível | ledger da infraestrutura de dados |
| 06 | Escritório de Projetos e Portal de Editais | equipe, volume de editais e projetos, 107 ações sem fomento |
| 07 | Visão 2027 | Espaço Colaborativo, integração, 2027 sistêmico |

## Procedência é design, não apêndice

Cada bloco carrega ficha técnica visível: **fonte, base, leitura e ressalva**. O título é "Transparência" — esconder a metodologia contradiria a peça.

## Seis divergências conferidas contra as APIs

Todas documentadas numa tabela no rodapé da própria página:

| Briefing | Publicado | Motivo |
|---|---|---|
| 44% de 4.845 | 43,8% de 7.938 | O percentual é sobre **atendimentos**, não pessoas únicas |
| bolsa R$ 800 | R$ 813–1.316 | `bolsa` preenchida em **23 dos 49**; R$813 é a menor, não a típica |
| sênior R$ 14.608 | R$ 17.073 | R$14.608 é o patamar de **8 anos de carreira** |
| renda × 8,1 | × 7,2 mediana | 8,0× é a média dos multiplicadores individuais |
| R$ 60 mi captados | dezenas de milhões | O relatório de origem declara **ordem de grandeza** e carrega aviso de estudo experimental |
| 70,1% do recurso | 70% do **FAPES** | A concentração medida não inclui FACTO |

Os três números da escada eram incompatíveis entre si no briefing: 800 × 8,1 = 6.480, não 14.608. A escada foi reconstruída sobre `serie-por-experiencia.json` e fecha.

## Implementação

- **Standalone**: sem dependência externa, sem webfont, tema claro/escuro por token, gráficos em SVG e CSS gerados dos dados no próprio arquivo. 58 KB.
- **Teclado**: setas, PageUp/PageDown, espaço, `j`/`k`, Home/End. Pílula de posição `3 / 9` e chip "última" a partir de 92%.
- **Barra de progresso**: a faixa institucional do IFES começa fantasma e ganha cor conforme avança — bandeira completa significa fim.
- **Sem JS a página continua inteira**: a revelação por scroll é enriquecimento, não requisito.
- `prefers-reduced-motion` respeitado; controles somem na impressão.

Verificado com `npm run build` (46 páginas indexadas) e renderização em Chrome headless nos quatro atos.

## Aberto

A entrada **não** está marcada como `destaque`. Promovê-la à home coloca um quarto card num grid de três colunas e deixa um órfão na segunda fileira — é decisão de layout, não técnica. Digam se querem e eu ajusto o grid junto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)