### PR TITLE
feat(balanco): modo apresentação em tela cheia, um bloco por tela

### DIFF
--- a/docs/relatorios/balanco-2026.html
+++ b/docs/relatorios/balanco-2026.html
@@ -359,6 +359,59 @@
   @media print{.navpill,.navhint{display:none;}}
   @media(max-width:620px){.navhint{display:none;} .navpill{right:14px;bottom:14px;}}
 
+
+  /* ============ MODO APRESENTAÇÃO ============
+     Cada bloco — capa, abertura de ato, figura, callout — vira um slide de
+     tela cheia com scroll-snap. O modo documento continua sendo o padrão:
+     é assim que a página é lida no site. */
+  :root[data-modo="slides"]{scroll-snap-type:y mandatory;scroll-behavior:smooth;}
+  :root[data-modo="slides"] .act{padding:0;border-bottom:0;}
+  :root[data-modo="slides"] .cover{padding:0;border-bottom:0;}
+  :root[data-modo="slides"] footer{padding:0;}
+  :root[data-modo="slides"] .act .head{grid-template-columns:1fr;gap:0;}
+  :root[data-modo="slides"] .act .num{display:none;}
+
+  :root[data-modo="slides"] .slide{
+    min-height:100dvh;display:flex;flex-direction:column;justify-content:center;
+    padding:9vh 0 7vh;scroll-snap-align:start;scroll-snap-stop:always;}
+  :root[data-modo="slides"] .fig{margin-top:0;}
+  :root[data-modo="slides"] .fig + .fig{margin-top:0;}
+  :root[data-modo="slides"] .callout{margin-top:0;}
+
+  /* a ficha continua na tela — só recua, porque num projetor ninguém lê 11px */
+  :root[data-modo="slides"] .ficha{opacity:.72;margin-top:16px;padding-top:10px;}
+  :root[data-modo="slides"] .ficha div{font-size:10.5px;}
+
+  /* aperto vertical: tudo precisa caber numa tela só */
+  :root[data-modo="slides"] .slide{padding:7vh 0 5vh;}
+  :root[data-modo="slides"] .fig{padding:20px 22px;}
+  :root[data-modo="slides"] .fig .cap{margin-bottom:16px;}
+  :root[data-modo="slides"] .hero-n{margin-bottom:18px;}
+  :root[data-modo="slides"] .hero-n .v{font-size:clamp(42px,7.5vmin,74px);}
+  :root[data-modo="slides"] .tm{height:min(400px,38vh);}
+  :root[data-modo="slides"] .tabela{margin-top:10px;}
+  :root[data-modo="slides"] .insight{margin-top:14px;padding:13px 16px;}
+  :root[data-modo="slides"] .legend{margin-top:14px;padding-top:12px;}
+  :root[data-modo="slides"] .stairs{min-height:min(340px,34vh);}
+  :root[data-modo="slides"] .curve{max-height:36vh;}
+
+  /* respiro maior para o texto de abertura de cada ato */
+  :root[data-modo="slides"] .intro h2{font-size:clamp(34px,6vmin,60px);}
+  :root[data-modo="slides"] .intro .lede{font-size:clamp(17px,2.4vmin,22px);max-width:56ch;}
+  :root[data-modo="slides"] .toc{display:none;}
+  /* projetor tem tela larga: aproveita */
+  :root[data-modo="slides"] .wrap{max-width:1340px;}
+
+  /* etiqueta do ato no canto de cada slide */
+  :root[data-modo="slides"] .slide[data-ato]::before{
+    content:attr(data-ato);position:absolute;left:28px;top:max(18px,4vh);
+    font-family:var(--mono);font-size:11.5px;letter-spacing:.1em;text-transform:uppercase;
+    color:var(--muted);}
+  :root[data-modo="slides"] .slide{position:relative;}
+
+  .navpill .modo{font-size:14px;}
+  :root[data-modo="slides"] .navpill .modo{background:var(--field);color:var(--ink);}
+
   /* tooltip */
   #tip{position:fixed;z-index:80;pointer-events:none;opacity:0;transition:opacity .1s;
     background:var(--ink);color:var(--paper);font-family:var(--mono);font-size:12px;
@@ -879,12 +932,14 @@
 </main>
 
 <nav class="navpill" aria-label="Navegação entre seções">
+  <button id="nav-modo" class="modo" type="button" aria-pressed="false"
+          aria-label="Alternar modo apresentação" title="Modo apresentação (tecla P) · tela cheia (F)">⛶</button>
   <button id="nav-prev" type="button" aria-label="Seção anterior" title="Seção anterior (↑)">↑</button>
   <span class="fim">última</span>
   <span class="pos" aria-live="polite"><b id="nav-i">1</b> / <span id="nav-n">9</span></span>
   <button id="nav-next" type="button" aria-label="Próxima seção" title="Próxima seção (↓)">↓</button>
 </nav>
-<div class="navhint" id="navhint"><kbd>↑</kbd> <kbd>↓</kbd> para navegar · <kbd>Home</kbd> <kbd>End</kbd></div>
+<div class="navhint" id="navhint"><kbd>↑</kbd> <kbd>↓</kbd> navegar · <kbd>P</kbd> apresentação · <kbd>F</kbd> tela cheia</div>
 
 <div id="tip" role="status" aria-live="polite"></div>
 
@@ -1055,6 +1110,7 @@
     window.addEventListener('resize', function(){
       clearTimeout(tmr); tmr = setTimeout(desenhaTM, 140);
     }, {passive: true});
+    window.addEventListener('relayout', desenhaTM);
   })();
 
   /* ---------- ato 3: escada ---------- */
@@ -1138,36 +1194,83 @@
     }
     bindTip(host, '<b>142 ações ativas de extensão</b><br>35 com fonte de fomento<br>' +
       '107 sem vínculo registrado<br>Fontes: 29 PAEX-IFES · 3 PRONATEC · 2 Mulheres Mil · 1 FAPES');
+    var recol = function(){
+      host.style.gridTemplateColumns =
+        'repeat(' + (window.matchMedia('(max-width:560px)').matches ? 14 : 26) + ',1fr)';
+    };
     var t;
     window.addEventListener('resize', function(){
-      clearTimeout(t);
-      t = setTimeout(function(){
-        host.style.gridTemplateColumns =
-          'repeat(' + (window.matchMedia('(max-width:560px)').matches ? 14 : 26) + ',1fr)';
-      }, 140);
+      clearTimeout(t); t = setTimeout(recol, 140);
     }, {passive: true});
+    window.addEventListener('relayout', recol);
   })();
 
-  /* ---------- navegação por teclado entre as seções ---------- */
+  /* ---------- slides, tela cheia e navegação por teclado ---------- */
   (function(){
-    var paradas = Array.prototype.slice.call(
-      document.querySelectorAll('section.cover, section.act, footer'));
-    if (!paradas.length) return;
+    var raiz = document.documentElement;
+
+    /* Marca os blocos que viram slide. A abertura de cada ato (eyebrow, título
+       e lead) ganha um wrapper próprio para poder ocupar a tela sozinha —
+       inofensivo no modo documento, indispensável no modo apresentação. */
+    (function marcar(){
+      var capa = document.querySelector('.cover .wrap');
+      if (capa) capa.classList.add('slide');
+      var rod = document.querySelector('footer .wrap');
+      if (rod) rod.classList.add('slide');
+
+      document.querySelectorAll('.act').forEach(function(act){
+        var col = act.querySelector('.head > div');
+        if (!col) return;
+        var rotulo = (act.querySelector('.eyebrow') || {}).textContent || '';
+        var abertura = [];
+        while (col.firstChild && !(col.firstChild.nodeType === 1 &&
+               /\b(fig|callout)\b/.test(col.firstChild.className || ''))){
+          abertura.push(col.firstChild); col.removeChild(col.firstChild);
+        }
+        if (abertura.length){
+          var box = document.createElement('div');
+          box.className = 'intro slide';
+          abertura.forEach(function(n){ box.appendChild(n); });
+          col.insertBefore(box, col.firstChild);
+        }
+        col.querySelectorAll(':scope > .fig, :scope > .callout').forEach(function(el){
+          el.classList.add('slide');
+          el.dataset.ato = rotulo;
+        });
+      });
+    })();
 
     var elI = document.getElementById('nav-i');
     var elN = document.getElementById('nav-n');
     var bPrev = document.getElementById('nav-prev');
     var bNext = document.getElementById('nav-next');
+    var bModo = document.getElementById('nav-modo');
     var hint = document.getElementById('navhint');
-    var atual = 0;
-    elN.textContent = paradas.length;
+    var barra = document.getElementById('prog');
+    var pilula = document.querySelector('.navpill');
 
+    var paradas = [], atual = 0;
     var suave = !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    var slides = function(){ return raiz.dataset.modo === 'slides'; };
 
+    function recalcula(){
+      paradas = Array.prototype.slice.call(document.querySelectorAll(
+        slides() ? '.slide' : 'section.cover, section.act, footer'));
+      elN.textContent = paradas.length;
+      if (atual >= paradas.length) atual = paradas.length - 1;
+      pinta();
+    }
     function pinta(){
       elI.textContent = atual + 1;
       bPrev.disabled = atual === 0;
       bNext.disabled = atual === paradas.length - 1;
+    }
+    function preenche(){
+      var rolavel = document.documentElement.scrollHeight - window.innerHeight;
+      var p = rolavel > 4 ? window.scrollY / rolavel : 1;
+      p = Math.max(0, Math.min(1, p));
+      if (barra) barra.style.width = (p * 100).toFixed(2) + '%';
+      if (pilula) pilula.dataset.fim = (p > 0.92 || atual === paradas.length - 1) ? '1' : '0';
     }
     function vai(i){
       atual = Math.max(0, Math.min(paradas.length - 1, i));
@@ -1176,25 +1279,13 @@
       if (hint && !hint.hidden){ hint.style.opacity = '0'; setTimeout(function(){ hint.hidden = true; }, 400); }
     }
 
-    /* qual seção domina a tela agora — mantém o contador certo no scroll livre */
-    var barra = document.getElementById('prog');
-    var pilula = document.querySelector('.navpill');
-    function preenche(){
-      var rolavel = document.documentElement.scrollHeight - window.innerHeight;
-      /* página que cabe inteira na tela já está 100% lida */
-      var p = rolavel > 4 ? window.scrollY / rolavel : 1;
-      p = Math.max(0, Math.min(1, p));
-      if (barra) barra.style.width = (p * 100).toFixed(2) + '%';
-      if (pilula) pilula.dataset.fim = (p > 0.92 || atual === paradas.length - 1) ? '1' : '0';
-    }
-
     var pendente = false;
     function sincroniza(){
       if (pendente) return;
       pendente = true;
       requestAnimationFrame(function(){
         pendente = false;
-        var alvo = window.innerHeight * 0.32, melhor = 0, dist = Infinity;
+        var alvo = window.innerHeight * (slides() ? 0.12 : 0.32), melhor = 0, dist = Infinity;
         paradas.forEach(function(el, i){
           var d = Math.abs(el.getBoundingClientRect().top - alvo);
           if (d < dist){ dist = d; melhor = i; }
@@ -1206,18 +1297,48 @@
     window.addEventListener('scroll', sincroniza, {passive: true});
     window.addEventListener('resize', sincroniza, {passive: true});
 
+    /* --------- modo apresentação --------- */
+    function trocaModo(ligar){
+      var ancora = paradas[atual];
+      if (ligar) raiz.dataset.modo = 'slides'; else raiz.removeAttribute('data-modo');
+      bModo.setAttribute('aria-pressed', String(!!ligar));
+      recalcula();
+      window.dispatchEvent(new Event('relayout'));
+      /* mantém o leitor onde estava: reancora no bloco mais próximo do anterior */
+      if (ancora){
+        var i = paradas.indexOf(ancora);
+        if (i < 0) i = paradas.findIndex(function(el){ return el.contains(ancora) || ancora.contains(el); });
+        if (i >= 0){ atual = i; paradas[i].scrollIntoView({block: 'start'}); pinta(); }
+      }
+      preenche();
+    }
+    function telaCheia(){
+      if (document.fullscreenElement) document.exitFullscreen();
+      else if (raiz.requestFullscreen) raiz.requestFullscreen().catch(function(){});
+    }
+    /* entrar em tela cheia liga o modo slides; sair não desliga — quem quer
+       projetar quase sempre quer os dois, mas pode querer só um deles. */
+    document.addEventListener('fullscreenchange', function(){
+      if (document.fullscreenElement && !slides()) trocaModo(true);
+      window.dispatchEvent(new Event('relayout'));
+    });
+    bModo.addEventListener('click', function(){ trocaModo(!slides()); });
+
     bPrev.addEventListener('click', function(){ vai(atual - 1); });
     bNext.addEventListener('click', function(){ vai(atual + 1); });
 
     var AVANCA = {ArrowDown: 1, ArrowRight: 1, PageDown: 1, ' ': 1, j: 1, n: 1};
-    var VOLTA  = {ArrowUp: 1, ArrowLeft: 1, PageUp: 1, k: 1, p: 1};
+    var VOLTA  = {ArrowUp: 1, ArrowLeft: 1, PageUp: 1, k: 1};
 
     document.addEventListener('keydown', function(e){
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       var alvo = e.target;
-      /* não sequestrar teclas de quem está digitando ou usando um controle */
       if (alvo && (alvo.isContentEditable ||
           /^(INPUT|TEXTAREA|SELECT|BUTTON|A)$/.test(alvo.tagName))) return;
+
+      var t = e.key.toLowerCase();
+      if (t === 'f'){ e.preventDefault(); telaCheia(); return; }
+      if (t === 'p'){ e.preventDefault(); trocaModo(!slides()); return; }
 
       if (AVANCA[e.key]){ e.preventDefault(); vai(atual + 1); }
       else if (VOLTA[e.key]){ e.preventDefault(); vai(atual - 1); }
@@ -1225,9 +1346,8 @@
       else if (e.key === 'End'){ e.preventDefault(); vai(paradas.length - 1); }
     });
 
-    pinta();
+    recalcula();
     preenche();
-    /* a dica some sozinha depois de um tempo, mesmo sem uso */
     if (hint) setTimeout(function(){
       hint.style.opacity = '0'; setTimeout(function(){ hint.hidden = true; }, 400);
     }, 7000);


### PR DESCRIPTION
O balanço nasceu como página de leitura, mas também é apresentado ao vivo. Em vez de escolher, ganha **dois modos**.

## Documento (padrão)

Rolagem contínua, como está hoje. É assim que a página é lida no site — nada muda para quem chega pelo link.

## Apresentação

A peça vira **24 slides** de tela cheia com scroll-snap: a capa, a abertura de cada ato, cada figura e cada callout. Um ato com três figuras vira quatro telas — nada disso caberia numa só.

Como entrar:

| | |
|---|---|
| Botão `⛶` na pílula | alterna o modo |
| Tecla `P` | alterna o modo |
| Tecla `F` | tela cheia — **liga o modo slides junto**, que é o que quem projeta quer |
| `↑` `↓` `PageUp/Down` `espaço` | andam de slide em slide |
| `Home` / `End` | primeiro / último |

Cada slide mostra no canto a que ato pertence, já que o número do ato sai da tela. O contador da pílula e a barra de progresso acompanham os slides.

## Implementação

- A abertura de cada ato ganha um wrapper `.intro` para poder ocupar a tela sozinha — inofensivo no modo documento.
- Ao trocar de modo, a página **reancora no bloco onde o leitor estava**, em vez de voltar ao topo.
- Treemap e waffle são redesenhados na troca de modo, via evento `relayout`, porque a largura muda.
- A ficha técnica continua na tela, só recuada. Num projetor ninguém lê 11px, mas quem pedir a fonte no meio da apresentação vai encontrá-la ali.

## Medição

Alturas apertadas no modo slides e verificadas em Chrome headless:

```
vh = 993 (1080p)  → nenhum slide estoura
vh = 853 (940px)  → nenhum slide estoura
vh = 726          → 2 slides passam por ~30px
```

726px é menor que qualquer projetor; nesses casos o slide rola um pouco.

🤖 Generated with [Claude Code](https://claude.com/claude-code)